### PR TITLE
Add service area pages for local SEO

### DIFF
--- a/src/_data/cities.json
+++ b/src/_data/cities.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Tustin & North Tustin",
+    "slug": "tustin",
+    "url": "/service-areas/tustin/"
+  },
+  {
+    "name": "Orange",
+    "slug": "orange",
+    "url": "/service-areas/orange/"
+  },
+  {
+    "name": "Villa Park",
+    "slug": "villa-park",
+    "url": "/service-areas/villa-park/"
+  },
+  {
+    "name": "Fullerton",
+    "slug": "fullerton",
+    "url": "/service-areas/fullerton/"
+  }
+]

--- a/src/_data/navigation.json
+++ b/src/_data/navigation.json
@@ -16,5 +16,11 @@
     { "label": "Landscape Lighting", "url": "/landscape-lighting/" },
     { "label": "Soil Health", "url": "/soil-health/" }
   ],
+  "serviceAreas": [
+    { "label": "Tustin & North Tustin", "url": "/service-areas/tustin/" },
+    { "label": "Orange", "url": "/service-areas/orange/" },
+    { "label": "Villa Park", "url": "/service-areas/villa-park/" },
+    { "label": "Fullerton", "url": "/service-areas/fullerton/" }
+  ],
   "footer": []
 }

--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -1,6 +1,6 @@
 <footer class="bg-forest text-white py-12">
   <div class="container mx-auto px-4">
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
       {# Company Info #}
       <div>
         <h3 class="text-xl font-bold mb-4">{{ site.name }}</h3>
@@ -18,6 +18,20 @@
           <li>
             <a href="{{ service.url }}" class="text-gray-300 hover:text-spring transition-colors">
               {{ service.label }}
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+
+      {# Service Areas #}
+      <div>
+        <h3 class="text-xl font-bold mb-4">Service Areas</h3>
+        <ul class="space-y-2">
+          {% for area in navigation.serviceAreas %}
+          <li>
+            <a href="{{ area.url }}" class="text-gray-300 hover:text-spring transition-colors">
+              {{ area.label }}
             </a>
           </li>
           {% endfor %}

--- a/src/index.njk
+++ b/src/index.njk
@@ -93,27 +93,23 @@ description: Expert landscape design and garden consultation in Orange County by
           <div class="grid grid-cols-2 md:grid-cols-3 gap-x-8 gap-y-3">
             <div class="flex items-center gap-2">
               <i class="fas fa-check text-lime text-sm"></i>
+              <a href="/service-areas/tustin/" class="text-gray-700 hover:text-forest transition-colors">Tustin & North Tustin</a>
+            </div>
+            <div class="flex items-center gap-2">
+              <i class="fas fa-check text-lime text-sm"></i>
+              <a href="/service-areas/orange/" class="text-gray-700 hover:text-forest transition-colors">Orange</a>
+            </div>
+            <div class="flex items-center gap-2">
+              <i class="fas fa-check text-lime text-sm"></i>
+              <a href="/service-areas/villa-park/" class="text-gray-700 hover:text-forest transition-colors">Villa Park</a>
+            </div>
+            <div class="flex items-center gap-2">
+              <i class="fas fa-check text-lime text-sm"></i>
+              <a href="/service-areas/fullerton/" class="text-gray-700 hover:text-forest transition-colors">Fullerton</a>
+            </div>
+            <div class="flex items-center gap-2">
+              <i class="fas fa-check text-lime text-sm"></i>
               <span class="text-gray-700">Lake Forest</span>
-            </div>
-            <div class="flex items-center gap-2">
-              <i class="fas fa-check text-lime text-sm"></i>
-              <span class="text-gray-700">Villa Park</span>
-            </div>
-            <div class="flex items-center gap-2">
-              <i class="fas fa-check text-lime text-sm"></i>
-              <span class="text-gray-700">Santa Ana</span>
-            </div>
-            <div class="flex items-center gap-2">
-              <i class="fas fa-check text-lime text-sm"></i>
-              <span class="text-gray-700">Orange</span>
-            </div>
-            <div class="flex items-center gap-2">
-              <i class="fas fa-check text-lime text-sm"></i>
-              <span class="text-gray-700">Costa Mesa</span>
-            </div>
-            <div class="flex items-center gap-2">
-              <i class="fas fa-check text-lime text-sm"></i>
-              <span class="text-gray-700">Tustin</span>
             </div>
             <div class="flex items-center gap-2">
               <i class="fas fa-check text-lime text-sm"></i>
@@ -121,7 +117,15 @@ description: Expert landscape design and garden consultation in Orange County by
             </div>
             <div class="flex items-center gap-2">
               <i class="fas fa-check text-lime text-sm"></i>
+              <span class="text-gray-700">Costa Mesa</span>
+            </div>
+            <div class="flex items-center gap-2">
+              <i class="fas fa-check text-lime text-sm"></i>
               <span class="text-gray-700">Newport Beach</span>
+            </div>
+            <div class="flex items-center gap-2">
+              <i class="fas fa-check text-lime text-sm"></i>
+              <span class="text-gray-700">Santa Ana</span>
             </div>
             <div class="flex items-center gap-2">
               <i class="fas fa-check text-lime text-sm"></i>

--- a/src/service-areas/fullerton.njk
+++ b/src/service-areas/fullerton.njk
@@ -1,0 +1,108 @@
+---
+layout: layouts/base.njk
+title: Landscape Design in Fullerton
+description: Professional landscape design, garden consultation, and hardscaping in Fullerton, CA. Serving historic neighborhoods, Hillcrest Park area, and all Fullerton communities.
+---
+
+{# Hero Section #}
+<section class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h1 class="text-5xl font-bold mb-8">Landscape Design in Fullerton, CA</h1>
+    <p class="text-lg text-gray-700 mb-8">
+      Professional landscape design for Fullerton's eclectic mix of historic homes, mid-century neighborhoods, and modern developments. We create gardens that match the personality of your property and your community.
+    </p>
+    <a href="/#contact" class="inline-block bg-coral text-stone px-8 py-4 rounded-full text-lg font-semibold hover:bg-sunset transition-colors">
+      Get a Free Consultation
+    </a>
+  </div>
+</section>
+
+{# Local Introduction #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-4xl">
+    <h2 class="text-4xl font-bold text-forest mb-6">Landscaping Fullerton's Diverse Neighborhoods</h2>
+    <p class="text-gray-700 mb-6">
+      Fullerton is a city of neighborhoods, each with its own architectural character and landscaping personality. The area surrounding Hillcrest Park features some of the city's most established homes—Craftsman bungalows, Spanish Revival, and early California ranch styles sitting on generous lots with mature trees and deep front yards. These properties benefit from renovation-style landscaping that preserves the best of what's there while refreshing tired plantings and updating irrigation.
+    </p>
+    <p class="text-gray-700 mb-6">
+      The mid-century neighborhoods south of Chapman Avenue and around Cal State Fullerton offer a different opportunity. These tract homes from the 1950s and 60s often have original landscapes that are ready for a complete transformation. Their moderate lot sizes are ideal for creating intimate outdoor living spaces—fire pits, dining patios, and garden beds that turn a standard backyard into a retreat.
+    </p>
+    <p class="text-gray-700">
+      Fullerton's newer developments near Amerige Heights and Coyote Hills feature contemporary homes with builder-grade landscaping that's functional but generic. Here, the goal is personalization—adding character through custom plantings, hardscape features, and lighting that make a new home feel established. Steve Lytle works across all of Fullerton's neighborhoods, adapting his designs to each property's style and scale.
+    </p>
+  </div>
+</section>
+
+{# Services for This Area #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Our Services in Fullerton</h2>
+    <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-leaf"></i></div>
+        <h3 class="text-xl font-bold mb-3">Garden Consultation</h3>
+        <p class="text-gray-700 mb-4">On-site property assessment covering soil quality, existing plantings, sun exposure, and drainage. Fullerton's older neighborhoods often have compacted clay soils that need specific amendment strategies for successful planting.</p>
+        <a href="/garden-consultation/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold mb-3">Plant Selection & Design</h3>
+        <p class="text-gray-700 mb-4">Plant palettes designed for Fullerton's warmer inland microclimate. We match plants to your home's architectural style—cottage perennials for Craftsman homes, clean Mediterranean lines for mid-century, and bold textures for contemporary properties.</p>
+        <a href="/plant-selection/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-mountain"></i></div>
+        <h3 class="text-xl font-bold mb-3">Hardscaping</h3>
+        <p class="text-gray-700 mb-4">Custom patios, walkways, fire features, and retaining walls. Fullerton's established neighborhoods have room for creative hardscape designs that extend your living space outdoors.</p>
+        <a href="/hardscaping/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-hand-holding-water"></i></div>
+        <h3 class="text-xl font-bold mb-3">Soil Health</h3>
+        <p class="text-gray-700 mb-4">Fullerton sits on heavy clay soil in many areas, particularly in older neighborhoods. Proper soil amendment and preparation is critical before planting. We test and amend your soil to give new plantings the best possible start.</p>
+        <a href="/soil-health/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# FAQ Section #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-3xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Fullerton Landscaping FAQ</h2>
+    <div class="space-y-8">
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What plants work best in Fullerton's climate?</h3>
+        <p class="text-gray-700">Fullerton is several miles inland, so it's warmer and drier than coastal Orange County. Heat-tolerant plants like crape myrtles, desert museum palo verde, and red yucca do well here. For shade, Chinese elm and tipu trees are popular. California natives like toyon, coffeeberry, and deer grass are excellent low-water choices that attract local birds and butterflies.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">How do I deal with Fullerton's clay soil?</h3>
+        <p class="text-gray-700">Clay soil is common throughout Fullerton, especially in the flatland neighborhoods. It retains water and can suffocate roots if not properly amended. We use a combination of gypsum applications, organic compost amendments, and raised planting areas to improve drainage. For existing gardens, we can top-dress and mulch to gradually improve soil structure over time.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">Are there tree removal restrictions in Fullerton?</h3>
+        <p class="text-gray-700">The City of Fullerton protects certain trees through its Municipal Code. Heritage trees and street trees require permits before removal. If you're planning a landscape renovation that involves removing existing trees, Steve can advise on which trees are protected and help design around significant specimens worth preserving.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What does a landscape consultation in Fullerton cost?</h3>
+        <p class="text-gray-700">Contact us for current consultation rates. Steve visits your Fullerton property to assess conditions, discuss your vision, and provide personalized recommendations. The consultation fee is applied toward your project if you move forward.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# CTA Section #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h2 class="text-4xl font-bold text-forest mb-6">Ready to Transform Your Fullerton Yard?</h2>
+    <p class="text-lg text-gray-700 mb-8">Schedule a consultation with Steve Lytle and start designing the outdoor space you've always wanted.</p>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a href="/#contact" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg font-semibold hover:bg-spring transition-colors">
+        Schedule Consultation
+      </a>
+      <a href="tel:{{ site.phoneRaw }}" class="inline-block border-2 border-forest text-forest px-8 py-4 rounded-lg font-semibold hover:bg-forest hover:text-white transition-colors">
+        Call {{ site.phone }}
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/service-areas/orange.njk
+++ b/src/service-areas/orange.njk
@@ -1,0 +1,108 @@
+---
+layout: layouts/base.njk
+title: Landscape Design in Orange
+description: Professional landscape design, garden consultation, and hardscaping in Orange, CA. Serving Old Towne, Orange Park Acres, and surrounding neighborhoods.
+---
+
+{# Hero Section #}
+<section class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h1 class="text-5xl font-bold mb-8">Landscape Design in Orange, CA</h1>
+    <p class="text-lg text-gray-700 mb-8">
+      From Old Towne's historic character homes to Orange Park Acres' sprawling equestrian properties, we design landscapes that honor the unique character of Orange, California.
+    </p>
+    <a href="/#contact" class="inline-block bg-coral text-stone px-8 py-4 rounded-full text-lg font-semibold hover:bg-sunset transition-colors">
+      Get a Free Consultation
+    </a>
+  </div>
+</section>
+
+{# Local Introduction #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-4xl">
+    <h2 class="text-4xl font-bold text-forest mb-6">Landscaping That Fits Orange's Character</h2>
+    <p class="text-gray-700 mb-6">
+      The City of Orange is one of the most distinctive communities in Orange County. Old Towne Orange—the largest National Register Historic District in California—is defined by its Craftsman bungalows, Spanish Colonial homes, and tree-lined streets. Landscaping here needs to complement the architectural heritage while meeting modern water-efficiency standards. We design gardens that feel timeless, using period-appropriate plantings alongside drought-tolerant varieties.
+    </p>
+    <p class="text-gray-700 mb-6">
+      Orange Park Acres offers a completely different canvas. These rural-residential properties, some over an acre, often include horse facilities, citrus groves, and open pasture. Landscape design here focuses on managing large spaces—creating distinct garden zones, establishing windbreaks, and designing around existing mature trees like the heritage oaks that define the area.
+    </p>
+    <p class="text-gray-700">
+      Neighborhoods like Villa Park adjacent areas, El Modena, and the communities near Chapman University each have their own character and lot sizes. Steve Lytle has been designing landscapes throughout Orange for over four decades, and he understands how to make every property—from a compact bungalow lot to a multi-acre estate—feel like home.
+    </p>
+  </div>
+</section>
+
+{# Services for This Area #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Our Services in Orange</h2>
+    <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold mb-3">Plant Selection & Design</h3>
+        <p class="text-gray-700 mb-4">Curated plant palettes that work with Orange's warm inland climate and complement the city's historic and rural architecture. From cottage gardens in Old Towne to native habitat restoration in Orange Park Acres.</p>
+        <a href="/plant-selection/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-mountain"></i></div>
+        <h3 class="text-xl font-bold mb-3">Hardscaping</h3>
+        <p class="text-gray-700 mb-4">Flagstone pathways, custom patios, and retaining walls that match Orange's architectural character. We use natural stone and materials that complement Craftsman, Spanish, and ranch-style homes.</p>
+        <a href="/hardscaping/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-lightbulb"></i></div>
+        <h3 class="text-xl font-bold mb-3">Landscape Lighting</h3>
+        <p class="text-gray-700 mb-4">Accent lighting that showcases Orange's beautiful architecture and mature trees after dark. Path lighting, uplighting, and entertaining-area illumination designed for safety and ambiance.</p>
+        <a href="/landscape-lighting/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-carrot"></i></div>
+        <h3 class="text-xl font-bold mb-3">Vegetable Gardens</h3>
+        <p class="text-gray-700 mb-4">Custom raised beds and edible gardens for Orange homeowners. Orange Park Acres properties have room for extensive kitchen gardens, while Old Towne lots benefit from compact, productive raised bed designs.</p>
+        <a href="/vegetable-gardens/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# FAQ Section #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-3xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Orange Landscaping FAQ</h2>
+    <div class="space-y-8">
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">Are there landscaping restrictions in Old Towne Orange?</h3>
+        <p class="text-gray-700">Properties within the Old Towne Historic District may be subject to design review by the Design Review Committee if exterior changes are visible from the street. While this primarily affects structures, significant landscape changes to front yards—like removing mature trees or adding hardscape—should be reviewed. Steve is familiar with these guidelines and designs accordingly.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What landscaping works best for Orange Park Acres horse properties?</h3>
+        <p class="text-gray-700">Equestrian properties need landscapes that are safe for horses—avoiding toxic plants like oleander, and using fencing-compatible designs. We create distinct zones separating garden areas from paddocks, with native plantings that reduce dust and manage drainage. Shade trees, windbreaks, and fire-resistant plantings are key considerations for these larger lots.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">How do I maintain mature trees on my Orange property?</h3>
+        <p class="text-gray-700">Orange is home to many heritage oaks, mature citrus groves, and established shade trees. Proper care includes appropriate watering zones (keeping irrigation away from trunk bases), annual health assessments, and designing new plantings that don't compete for root space. Steve's horticultural training includes arboriculture, and he factors existing trees into every design.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What does a landscape consultation in Orange cost?</h3>
+        <p class="text-gray-700">Contact us for current consultation rates. Steve visits your Orange property to assess conditions, discuss your goals, and provide personalized design recommendations. The consultation fee is credited toward your project if you proceed.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# CTA Section #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h2 class="text-4xl font-bold text-forest mb-6">Ready to Transform Your Orange Property?</h2>
+    <p class="text-lg text-gray-700 mb-8">Schedule a consultation with Steve Lytle and start designing the outdoor space you've always wanted.</p>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a href="/#contact" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg font-semibold hover:bg-spring transition-colors">
+        Schedule Consultation
+      </a>
+      <a href="tel:{{ site.phoneRaw }}" class="inline-block border-2 border-forest text-forest px-8 py-4 rounded-lg font-semibold hover:bg-forest hover:text-white transition-colors">
+        Call {{ site.phone }}
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/service-areas/tustin.njk
+++ b/src/service-areas/tustin.njk
@@ -1,0 +1,108 @@
+---
+layout: layouts/base.njk
+title: Landscape Design in Tustin & North Tustin
+description: Professional landscape design, garden consultation, and hardscaping in Tustin and North Tustin, CA. Over 40 years serving Orange County homeowners.
+---
+
+{# Hero Section #}
+<section class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h1 class="text-5xl font-bold mb-8">Landscape Design in Tustin & North Tustin, CA</h1>
+    <p class="text-lg text-gray-700 mb-8">
+      Professional landscape design and horticultural services for Tustin and North Tustin homeowners. From hillside estates to Old Town cottages, we create outdoor spaces that work with your property's unique character.
+    </p>
+    <a href="/#contact" class="inline-block bg-coral text-stone px-8 py-4 rounded-full text-lg font-semibold hover:bg-sunset transition-colors">
+      Get a Free Consultation
+    </a>
+  </div>
+</section>
+
+{# Local Introduction #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-4xl">
+    <h2 class="text-4xl font-bold text-forest mb-6">Landscaping for Tustin's Diverse Properties</h2>
+    <p class="text-gray-700 mb-6">
+      Tustin and North Tustin offer some of Orange County's most diverse landscaping opportunities. North Tustin's hillside properties along Lemon Heights and Cowan Heights feature expansive lots with dramatic elevation changes, mature oak and eucalyptus groves, and panoramic views that demand thoughtful landscape design. These larger estates benefit from terraced garden beds, drought-tolerant native plantings, and hardscape features that work with the natural slope.
+    </p>
+    <p class="text-gray-700 mb-6">
+      In Old Town Tustin, charming bungalows and mid-century homes sit on more compact lots where every square foot counts. Here, the challenge is creating a sense of spaciousness through smart plant selection, vertical gardening, and multi-use outdoor living areas. The tree-lined streets and established neighborhood character call for designs that feel rooted and intentional.
+    </p>
+    <p class="text-gray-700">
+      Tustin Ranch and newer developments like Columbus Grove present their own opportunities—clean-slate yards ready for complete landscape transformations. Whether you're working with a blank canvas or refreshing an established garden, Steve Lytle brings over four decades of local horticultural expertise to every Tustin project.
+    </p>
+  </div>
+</section>
+
+{# Services for This Area #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Our Services in Tustin & North Tustin</h2>
+    <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-leaf"></i></div>
+        <h3 class="text-xl font-bold mb-3">Garden Consultation</h3>
+        <p class="text-gray-700 mb-4">On-site assessment of your Tustin property's soil, sun exposure, and microclimates. Personalized design recommendations that account for North Tustin's hillside conditions or Old Town's compact lots.</p>
+        <a href="/garden-consultation/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold mb-3">Plant Selection & Design</h3>
+        <p class="text-gray-700 mb-4">Expert plant choices suited to Tustin's inland microclimate. We specialize in drought-tolerant natives, Mediterranean varieties, and low-maintenance plantings that thrive in the warmer temperatures away from the coast.</p>
+        <a href="/plant-selection/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-mountain"></i></div>
+        <h3 class="text-xl font-bold mb-3">Hardscaping</h3>
+        <p class="text-gray-700 mb-4">Custom patios, retaining walls, and walkways designed for Tustin's terrain. North Tustin hillside properties often need terracing and erosion control integrated into beautiful hardscape designs.</p>
+        <a href="/hardscaping/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-carrot"></i></div>
+        <h3 class="text-xl font-bold mb-3">Vegetable Gardens</h3>
+        <p class="text-gray-700 mb-4">Custom cedar raised beds perfect for Tustin's growing season. The inland warmth gives you a longer harvest window for tomatoes, peppers, citrus, and year-round herbs.</p>
+        <a href="/vegetable-gardens/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# FAQ Section #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-3xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Tustin Landscaping FAQ</h2>
+    <div class="space-y-8">
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What plants grow best in Tustin's climate?</h3>
+        <p class="text-gray-700">Tustin sits a few miles inland, so temperatures run warmer than coastal cities. Drought-tolerant natives like California buckwheat, manzanita, and Cleveland sage do exceptionally well. For color, lantana, bougainvillea, and lavender thrive. Citrus trees are a staple of Tustin gardens—the area's history as an orange grove region means the soil is well-suited for them.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">Do I need a permit for hardscaping in Tustin?</h3>
+        <p class="text-gray-700">The City of Tustin requires permits for retaining walls over 3 feet, significant grading work, and structures like pergolas or outdoor kitchens. North Tustin, being an unincorporated area of Orange County, follows county permitting rules which can differ. Steve handles the permitting process as part of every hardscape project.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">How do I landscape a hillside property in North Tustin?</h3>
+        <p class="text-gray-700">Hillside landscaping requires careful planning for erosion control, drainage, and fire safety. We use a combination of terraced retaining walls, deep-rooted native plants, and proper grading to create beautiful, stable hillside gardens. Fire-resistant plant choices are especially important for properties near Peters Canyon Regional Park and the surrounding open spaces.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What does a landscape consultation in Tustin cost?</h3>
+        <p class="text-gray-700">Contact us for current consultation rates. Every project starts with an on-site visit where Steve assesses your property, discusses your goals, and provides personalized recommendations. The consultation fee is applied toward your project if you move forward.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# CTA Section #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h2 class="text-4xl font-bold text-forest mb-6">Ready to Transform Your Tustin Yard?</h2>
+    <p class="text-lg text-gray-700 mb-8">Schedule a consultation with Steve Lytle and start designing the outdoor space you've always wanted.</p>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a href="/#contact" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg font-semibold hover:bg-spring transition-colors">
+        Schedule Consultation
+      </a>
+      <a href="tel:{{ site.phoneRaw }}" class="inline-block border-2 border-forest text-forest px-8 py-4 rounded-lg font-semibold hover:bg-forest hover:text-white transition-colors">
+        Call {{ site.phone }}
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/service-areas/villa-park.njk
+++ b/src/service-areas/villa-park.njk
@@ -1,0 +1,108 @@
+---
+layout: layouts/base.njk
+title: Landscape Design in Villa Park
+description: Professional landscape design and garden consultation in Villa Park, CA. Estate landscaping, large lot design, and expert horticultural services.
+---
+
+{# Hero Section #}
+<section class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h1 class="text-5xl font-bold mb-8">Landscape Design in Villa Park, CA</h1>
+    <p class="text-lg text-gray-700 mb-8">
+      Estate-quality landscape design for Villa Park's spacious properties. We create outdoor environments that make the most of your generous lot while reflecting the community's relaxed, semi-rural character.
+    </p>
+    <a href="/#contact" class="inline-block bg-coral text-stone px-8 py-4 rounded-full text-lg font-semibold hover:bg-sunset transition-colors">
+      Get a Free Consultation
+    </a>
+  </div>
+</section>
+
+{# Local Introduction #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-4xl">
+    <h2 class="text-4xl font-bold text-forest mb-6">Landscaping Villa Park's Estate Properties</h2>
+    <p class="text-gray-700 mb-6">
+      Villa Park is one of Orange County's best-kept secrets for homeowners who want space. As one of the smallest cities in the county by population but one of the most generous in lot sizes, Villa Park properties typically start at 10,000 square feet and many exceed half an acre. This gives landscape designers a rare canvas—room for distinct garden zones, mature specimen trees, expansive lawns, and integrated outdoor living spaces that simply aren't possible on standard suburban lots.
+    </p>
+    <p class="text-gray-700 mb-6">
+      The city's equestrian heritage runs deep. Many properties still maintain horse facilities, and the community's rural-suburban character shapes the expectation for landscaping: natural, established, and unpretentious. Residents want gardens that look like they've been growing for decades, not installed last month. This means careful plant selection, proper soil preparation, and designs built around existing mature trees rather than starting from scratch.
+    </p>
+    <p class="text-gray-700">
+      Villa Park's location along Santiago Creek and near the Santiago Oaks Regional Park also means many properties border open space or riparian areas. Designing landscapes that transition gracefully from cultivated garden to natural habitat is one of Steve Lytle's specialties—blending native and ornamental plantings in a way that feels seamless.
+    </p>
+  </div>
+</section>
+
+{# Services for This Area #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Our Services in Villa Park</h2>
+    <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-leaf"></i></div>
+        <h3 class="text-xl font-bold mb-3">Garden Consultation</h3>
+        <p class="text-gray-700 mb-4">Comprehensive property assessment for Villa Park's larger lots. Steve evaluates existing trees, soil conditions across different zones, sun and shade patterns, and drainage to create a cohesive design for your entire property.</p>
+        <a href="/garden-consultation/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold mb-3">Plant Selection & Design</h3>
+        <p class="text-gray-700 mb-4">Specimen tree placement, understory plantings, and garden bed designs scaled for Villa Park's estate-sized properties. We select plants that establish quickly and grow into a mature, layered landscape.</p>
+        <a href="/plant-selection/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-faucet"></i></div>
+        <h3 class="text-xl font-bold mb-3">Irrigation Systems</h3>
+        <p class="text-gray-700 mb-4">Multi-zone irrigation designed for large properties with varying water needs. Smart controllers, drip zones for garden beds, and efficient sprinkler coverage for lawns—all designed to conserve water across your entire lot.</p>
+        <a href="/irrigation-systems/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-lightbulb"></i></div>
+        <h3 class="text-xl font-bold mb-3">Landscape Lighting</h3>
+        <p class="text-gray-700 mb-4">Villa Park's large lots deserve lighting that creates depth and drama. We design layered lighting plans with path lights, tree uplighting, and accent features that transform your property after sunset.</p>
+        <a href="/landscape-lighting/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# FAQ Section #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-3xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Villa Park Landscaping FAQ</h2>
+    <div class="space-y-8">
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">How do I landscape a large Villa Park lot without it looking bare?</h3>
+        <p class="text-gray-700">The key is creating distinct zones—outdoor living areas, garden rooms, orchard sections, and naturalized borders. Strategic placement of specimen trees and mid-size shrubs provides structure, while ground covers and perennials fill in the gaps. Steve designs in layers, starting with the canopy trees and working down, so even a newly planted garden has visual weight and structure.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What should I know about landscaping near Santiago Creek?</h3>
+        <p class="text-gray-700">Properties near Santiago Creek or the Santiago Oaks open space should use native and fire-resistant plants in transition zones. There may be setback requirements and drainage considerations. We design buffers using native sycamores, coast live oaks, toyon, and native grasses that blend your garden into the surrounding natural landscape while meeting fire safety guidelines.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">Can you design around existing horse facilities?</h3>
+        <p class="text-gray-700">Absolutely. Many Villa Park properties include stables, arenas, and paddocks. We design landscapes that create attractive screening between living areas and equestrian facilities, use horse-safe plants (avoiding toxic species like oleander and red maple), and integrate functional elements like shade trees for paddocks and dust-reducing ground covers.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What does a landscape consultation in Villa Park cost?</h3>
+        <p class="text-gray-700">Contact us for current consultation rates. Given Villa Park's larger properties, consultations typically involve a thorough walkthrough of the entire lot. The consultation fee is credited toward your project if you proceed.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# CTA Section #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h2 class="text-4xl font-bold text-forest mb-6">Ready to Transform Your Villa Park Estate?</h2>
+    <p class="text-lg text-gray-700 mb-8">Schedule a consultation with Steve Lytle and start designing the outdoor space your property deserves.</p>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a href="/#contact" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg font-semibold hover:bg-spring transition-colors">
+        Schedule Consultation
+      </a>
+      <a href="tel:{{ site.phoneRaw }}" class="inline-block border-2 border-forest text-forest px-8 py-4 rounded-lg font-semibold hover:bg-forest hover:text-white transition-colors">
+        Call {{ site.phone }}
+      </a>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- 4 new city landing pages at `/service-areas/{city}/` — Tustin & North Tustin, Orange, Villa Park, Fullerton
- Each page has unique local content: neighborhood references, property types, climate notes, local FAQs
- Homepage "Areas We Serve" now links to city pages (added North Tustin and Fullerton)
- Footer adds "Service Areas" column with links to all city pages
- Sitemap automatically includes all new pages

## City content angles
- **Tustin** — North Tustin hillside estates, Old Town, Tustin Ranch, Peters Canyon fire safety
- **Orange** — Old Towne historic district, Orange Park Acres equestrian, El Modena, mature tree care
- **Villa Park** — Estate lots 10k+ sq ft, equestrian heritage, Santiago Creek/Oaks, habitat transition
- **Fullerton** — Hillcrest Park historic homes, mid-century tracts, clay soil challenges, tree protections

## Test plan
- [ ] All 4 city pages render at correct URLs with trailing slashes
- [ ] Sitemap includes all 4 service area URLs
- [ ] Homepage "Areas We Serve" links work
- [ ] Footer shows new "Service Areas" column
- [ ] Footer is 4-column on desktop, 2-column on tablet, stacked on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)