### PR TITLE
Add 7 service area pages and fix meta descriptions

### DIFF
--- a/src/_data/cities.json
+++ b/src/_data/cities.json
@@ -18,5 +18,40 @@
     "name": "Fullerton",
     "slug": "fullerton",
     "url": "/service-areas/fullerton/"
+  },
+  {
+    "name": "Lake Forest",
+    "slug": "lake-forest",
+    "url": "/service-areas/lake-forest/"
+  },
+  {
+    "name": "Irvine",
+    "slug": "irvine",
+    "url": "/service-areas/irvine/"
+  },
+  {
+    "name": "Costa Mesa",
+    "slug": "costa-mesa",
+    "url": "/service-areas/costa-mesa/"
+  },
+  {
+    "name": "Newport Beach",
+    "slug": "newport-beach",
+    "url": "/service-areas/newport-beach/"
+  },
+  {
+    "name": "Santa Ana",
+    "slug": "santa-ana",
+    "url": "/service-areas/santa-ana/"
+  },
+  {
+    "name": "Mission Viejo",
+    "slug": "mission-viejo",
+    "url": "/service-areas/mission-viejo/"
+  },
+  {
+    "name": "Rancho Santa Margarita",
+    "slug": "rancho-santa-margarita",
+    "url": "/service-areas/rancho-santa-margarita/"
   }
 ]

--- a/src/_data/navigation.json
+++ b/src/_data/navigation.json
@@ -20,7 +20,14 @@
     { "label": "Tustin & North Tustin", "url": "/service-areas/tustin/" },
     { "label": "Orange", "url": "/service-areas/orange/" },
     { "label": "Villa Park", "url": "/service-areas/villa-park/" },
-    { "label": "Fullerton", "url": "/service-areas/fullerton/" }
+    { "label": "Fullerton", "url": "/service-areas/fullerton/" },
+    { "label": "Lake Forest", "url": "/service-areas/lake-forest/" },
+    { "label": "Irvine", "url": "/service-areas/irvine/" },
+    { "label": "Costa Mesa", "url": "/service-areas/costa-mesa/" },
+    { "label": "Newport Beach", "url": "/service-areas/newport-beach/" },
+    { "label": "Santa Ana", "url": "/service-areas/santa-ana/" },
+    { "label": "Mission Viejo", "url": "/service-areas/mission-viejo/" },
+    { "label": "Rancho Santa Margarita", "url": "/service-areas/rancho-santa-margarita/" }
   ],
   "footer": []
 }

--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -48,7 +48,8 @@
       "Costa Mesa",
       "Newport Beach",
       "Mission Viejo",
-      "Santa Ana"
+      "Santa Ana",
+      "Rancho Santa Margarita"
     ]
   }
 }

--- a/src/index.njk
+++ b/src/index.njk
@@ -88,7 +88,7 @@ description: Expert landscape design and garden consultation in Orange County by
         <div class="bg-white shadow-lg rounded-xl p-8">
           <div class="flex items-center gap-3 mb-6">
             <i class="fas fa-map-marker-alt text-2xl text-lime"></i>
-            <h3 class="text-xl font-bold text-forest">Areas We Serve</h3>
+            <h3 class="text-xl font-bold text-forest">Some of the Areas We Serve</h3>
           </div>
           <div class="grid grid-cols-2 md:grid-cols-3 gap-x-8 gap-y-3">
             <div class="flex items-center gap-2">
@@ -109,27 +109,31 @@ description: Expert landscape design and garden consultation in Orange County by
             </div>
             <div class="flex items-center gap-2">
               <i class="fas fa-check text-lime text-sm"></i>
-              <span class="text-gray-700">Lake Forest</span>
+              <a href="/service-areas/lake-forest/" class="text-gray-700 hover:text-forest transition-colors">Lake Forest</a>
             </div>
             <div class="flex items-center gap-2">
               <i class="fas fa-check text-lime text-sm"></i>
-              <span class="text-gray-700">Irvine</span>
+              <a href="/service-areas/irvine/" class="text-gray-700 hover:text-forest transition-colors">Irvine</a>
             </div>
             <div class="flex items-center gap-2">
               <i class="fas fa-check text-lime text-sm"></i>
-              <span class="text-gray-700">Costa Mesa</span>
+              <a href="/service-areas/costa-mesa/" class="text-gray-700 hover:text-forest transition-colors">Costa Mesa</a>
             </div>
             <div class="flex items-center gap-2">
               <i class="fas fa-check text-lime text-sm"></i>
-              <span class="text-gray-700">Newport Beach</span>
+              <a href="/service-areas/newport-beach/" class="text-gray-700 hover:text-forest transition-colors">Newport Beach</a>
             </div>
             <div class="flex items-center gap-2">
               <i class="fas fa-check text-lime text-sm"></i>
-              <span class="text-gray-700">Santa Ana</span>
+              <a href="/service-areas/santa-ana/" class="text-gray-700 hover:text-forest transition-colors">Santa Ana</a>
             </div>
             <div class="flex items-center gap-2">
               <i class="fas fa-check text-lime text-sm"></i>
-              <span class="text-gray-700">Mission Viejo</span>
+              <a href="/service-areas/mission-viejo/" class="text-gray-700 hover:text-forest transition-colors">Mission Viejo</a>
+            </div>
+            <div class="flex items-center gap-2">
+              <i class="fas fa-check text-lime text-sm"></i>
+              <a href="/service-areas/rancho-santa-margarita/" class="text-gray-700 hover:text-forest transition-colors">Rancho Santa Margarita</a>
             </div>
           </div>
         </div>

--- a/src/service-areas/costa-mesa.njk
+++ b/src/service-areas/costa-mesa.njk
@@ -1,0 +1,108 @@
+---
+layout: layouts/base.njk
+title: Landscape Design in Costa Mesa
+description: Landscape design and garden consultation in Costa Mesa, CA. Serving Mesa Verde, Eastside, South Coast Metro, and all Costa Mesa neighborhoods.
+---
+
+{# Hero Section #}
+<section class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h1 class="text-5xl font-bold mb-8">Landscape Design in Costa Mesa, CA</h1>
+    <p class="text-lg text-gray-700 mb-8">
+      Professional landscape design for Costa Mesa's eclectic neighborhoods. From Mesa Verde's established properties to the Eastside's bungalow-lined streets, we create gardens that fit your home and lifestyle.
+    </p>
+    <a href="/#contact" class="inline-block bg-coral text-stone px-8 py-4 rounded-full text-lg font-semibold hover:bg-sunset transition-colors">
+      Get a Free Consultation
+    </a>
+  </div>
+</section>
+
+{# Local Introduction #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-4xl">
+    <h2 class="text-4xl font-bold text-forest mb-6">Landscaping Costa Mesa's Diverse Neighborhoods</h2>
+    <p class="text-gray-700 mb-6">
+      Costa Mesa offers some of the most varied residential character in Orange County. Mesa Verde, the city's largest planned neighborhood, features mid-century ranch homes from the 1960s on generous lots with mature shade trees. Many of these properties still have original landscapes—aging turf, overgrown foundation shrubs, and irrigation systems past their prime. A well-planned renovation can transform these yards without starting from scratch, preserving healthy trees while refreshing everything around them.
+    </p>
+    <p class="text-gray-700 mb-6">
+      The Eastside neighborhoods near 17th Street and Newport Boulevard have a completely different feel—smaller bungalows, cottages, and newer infill homes on compact lots. Here, every planting decision matters because the space is intimate. Cottage-style gardens, vertical plantings, and multi-use patios work well, creating outdoor rooms that feel larger than their footprint. The proximity to the coast gives Eastside gardens a mild climate advantage that supports a wider range of plants than inland areas.
+    </p>
+    <p class="text-gray-700">
+      Costa Mesa's South Coast area near South Coast Plaza and the Segerstrom Center features newer townhomes and condos alongside established single-family neighborhoods. These properties range from postage-stamp courtyards to full front-and-back yards, each with unique design possibilities. Steve Lytle creates custom designs for all of Costa Mesa's neighborhoods, working with each property's scale, architecture, and microclimate.
+    </p>
+  </div>
+</section>
+
+{# Services for This Area #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Our Services in Costa Mesa</h2>
+    <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-leaf"></i></div>
+        <h3 class="text-xl font-bold mb-3">Garden Consultation</h3>
+        <p class="text-gray-700 mb-4">On-site assessment of your Costa Mesa property covering soil quality, drainage, sun patterns, and existing plantings. We evaluate what to keep, what to refresh, and what to replace for maximum impact within your budget.</p>
+        <a href="/garden-consultation/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold mb-3">Plant Selection & Design</h3>
+        <p class="text-gray-700 mb-4">Plant choices suited to Costa Mesa's coastal-influenced climate. The mild temperatures and ocean moisture support everything from Mediterranean herbs and succulents to subtropical flowering plants that struggle just a few miles inland.</p>
+        <a href="/plant-selection/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-mountain"></i></div>
+        <h3 class="text-xl font-bold mb-3">Hardscaping</h3>
+        <p class="text-gray-700 mb-4">Patios, walkways, and outdoor living features designed for Costa Mesa's lot sizes. We specialize in making compact spaces feel spacious through smart layout, integrated seating, and multi-function hardscape elements.</p>
+        <a href="/hardscaping/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-carrot"></i></div>
+        <h3 class="text-xl font-bold mb-3">Vegetable Gardens</h3>
+        <p class="text-gray-700 mb-4">Cedar raised bed gardens sized for Costa Mesa backyards. The coastal climate allows nearly year-round growing—cool-season greens in winter, tomatoes and peppers through summer, and herbs that produce twelve months a year.</p>
+        <a href="/vegetable-gardens/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# FAQ Section #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-3xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Costa Mesa Landscaping FAQ</h2>
+    <div class="space-y-8">
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What plants grow best near the coast in Costa Mesa?</h3>
+        <p class="text-gray-700">Costa Mesa's proximity to the ocean means milder temperatures but also salt air exposure. Salt-tolerant plants like New Zealand flax, rosemary, agave, and star jasmine do well here. The mild winters also allow subtropical plants like bird of paradise, plumeria, and hibiscus that wouldn't survive further inland.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">How do I update a mid-century landscape in Mesa Verde?</h3>
+        <p class="text-gray-700">Many Mesa Verde homes still have 1960s-era landscapes with water-hungry lawns and overgrown shrubs. We take a renovation approach—assessing what's worth keeping (mature trees, healthy hardscape) and replacing the rest with drought-tolerant plantings and updated irrigation. The result is a modern garden that respects the home's mid-century character.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">Are there water restrictions for landscaping in Costa Mesa?</h3>
+        <p class="text-gray-700">Costa Mesa is served by Mesa Water District, which follows state water-efficiency requirements. New landscapes must meet water-use efficiency standards, and turf area is limited in new installations. We design with these regulations in mind, creating beautiful gardens that stay well within water budgets.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What does a landscape consultation in Costa Mesa cost?</h3>
+        <p class="text-gray-700">Contact us for current consultation rates. Steve visits your Costa Mesa property to assess conditions, discuss your vision, and provide personalized recommendations. The consultation fee is applied toward your project if you move forward.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# CTA Section #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h2 class="text-4xl font-bold text-forest mb-6">Ready to Transform Your Costa Mesa Yard?</h2>
+    <p class="text-lg text-gray-700 mb-8">Schedule a consultation with Steve Lytle and start designing the outdoor space you've always wanted.</p>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a href="/#contact" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg font-semibold hover:bg-spring transition-colors">
+        Schedule Consultation
+      </a>
+      <a href="tel:{{ site.phoneRaw }}" class="inline-block border-2 border-forest text-forest px-8 py-4 rounded-lg font-semibold hover:bg-forest hover:text-white transition-colors">
+        Call {{ site.phone }}
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/service-areas/fullerton.njk
+++ b/src/service-areas/fullerton.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/base.njk
 title: Landscape Design in Fullerton
-description: Professional landscape design, garden consultation, and hardscaping in Fullerton, CA. Serving historic neighborhoods, Hillcrest Park area, and all Fullerton communities.
+description: Landscape design, garden consultation, and hardscaping in Fullerton, CA. Serving Hillcrest Park, Amerige Heights, and all Fullerton neighborhoods.
 ---
 
 {# Hero Section #}

--- a/src/service-areas/irvine.njk
+++ b/src/service-areas/irvine.njk
@@ -1,0 +1,108 @@
+---
+layout: layouts/base.njk
+title: Landscape Design in Irvine
+description: Landscape design and garden consultation in Irvine, CA. HOA-compliant designs for Woodbridge, Turtle Rock, Northwood, and all Irvine villages.
+---
+
+{# Hero Section #}
+<section class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h1 class="text-5xl font-bold mb-8">Landscape Design in Irvine, CA</h1>
+    <p class="text-lg text-gray-700 mb-8">
+      Professional landscape design for Irvine's planned communities. HOA-compliant garden designs that maximize your outdoor space while meeting community standards and water-efficiency requirements.
+    </p>
+    <a href="/#contact" class="inline-block bg-coral text-stone px-8 py-4 rounded-full text-lg font-semibold hover:bg-sunset transition-colors">
+      Get a Free Consultation
+    </a>
+  </div>
+</section>
+
+{# Local Introduction #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-4xl">
+    <h2 class="text-4xl font-bold text-forest mb-6">Landscaping Irvine's Planned Communities</h2>
+    <p class="text-gray-700 mb-6">
+      Irvine's village system creates distinct neighborhoods, each with its own architectural character and landscape guidelines. Turtle Rock, one of the city's earliest communities, sits against the San Joaquin Hills with larger lots, mature trees, and established gardens that often need updating. The homes here have room for creative designs—terraced hillside plantings, specimen trees, and outdoor living spaces that take advantage of the elevation and views.
+    </p>
+    <p class="text-gray-700 mb-6">
+      Woodbridge, built around its two lakes, has a more traditional suburban feel with moderate lots and strong HOA oversight. The challenge here is creating distinctive gardens within well-defined guidelines. We work with Woodbridge homeowners to maximize curb appeal and backyard livability using approved plant palettes and hardscape materials that complement the community's aesthetic.
+    </p>
+    <p class="text-gray-700">
+      Newer Irvine communities near the Great Park—Pavilion Park, Parasol Park, and the Beacon Park neighborhoods—feature contemporary architecture on tighter lots where every square foot matters. Builder-installed landscaping is typically minimal. These properties are ideal for vertical gardens, multi-function hardscape, and compact raised bed vegetable gardens that make small backyards productive and beautiful. Steve Lytle designs for all of Irvine's villages, navigating HOA requirements while delivering gardens with genuine character.
+    </p>
+  </div>
+</section>
+
+{# Services for This Area #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Our Services in Irvine</h2>
+    <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-leaf"></i></div>
+        <h3 class="text-xl font-bold mb-3">Garden Consultation</h3>
+        <p class="text-gray-700 mb-4">On-site property assessment including HOA guideline review, soil evaluation, and design feasibility. We understand Irvine's community-specific requirements and design within them from the start, avoiding costly revision cycles.</p>
+        <a href="/garden-consultation/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold mb-3">Plant Selection & Design</h3>
+        <p class="text-gray-700 mb-4">Water-efficient plant palettes that meet Irvine's landscape requirements. We select drought-tolerant varieties that provide color and texture year-round while keeping your water use within city and HOA mandates.</p>
+        <a href="/plant-selection/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-tint"></i></div>
+        <h3 class="text-xl font-bold mb-3">Irrigation Systems</h3>
+        <p class="text-gray-700 mb-4">Smart irrigation design and retrofits for Irvine properties. High-efficiency drip systems and weather-based controllers that satisfy IRWD water budgets and keep your plants healthy during dry months.</p>
+        <a href="/irrigation-systems/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-mountain"></i></div>
+        <h3 class="text-xl font-bold mb-3">Hardscaping</h3>
+        <p class="text-gray-700 mb-4">Patios, walkways, and retaining walls designed for Irvine's compact and mid-size lots. Multi-function hardscape that extends your living space outdoors while meeting community architectural standards.</p>
+        <a href="/hardscaping/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# FAQ Section #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-3xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Irvine Landscaping FAQ</h2>
+    <div class="space-y-8">
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">How do I get HOA approval for landscaping in Irvine?</h3>
+        <p class="text-gray-700">Most Irvine villages require architectural review before landscape changes. Steve prepares HOA-ready design packages that include plant lists, hardscape materials, and site plans formatted for your community's review process. Working within the guidelines from the start avoids delays and rework.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What are Irvine's water-efficient landscaping requirements?</h3>
+        <p class="text-gray-700">The Irvine Ranch Water District (IRWD) assigns water budgets to each property. Landscapes with high-water-use turf often exceed these budgets, triggering surcharges. We design with IRWD guidelines in mind, using drought-tolerant plants, efficient drip irrigation, and permeable surfaces to keep your water use well within budget.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">Can I replace my lawn with drought-tolerant landscaping?</h3>
+        <p class="text-gray-700">Yes, and IRWD often offers rebates for turf removal. We design lawn replacements that look lush without the water waste—using decomposed granite pathways, native grasses, flowering perennials, and mulched garden beds that stay green and inviting year-round.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What does a landscape consultation in Irvine cost?</h3>
+        <p class="text-gray-700">Contact us for current consultation rates. Steve visits your Irvine property to assess conditions, review HOA requirements, and provide personalized recommendations. The consultation fee is applied toward your project if you move forward.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# CTA Section #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h2 class="text-4xl font-bold text-forest mb-6">Ready to Transform Your Irvine Yard?</h2>
+    <p class="text-lg text-gray-700 mb-8">Schedule a consultation with Steve Lytle and start designing the outdoor space you've always wanted.</p>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a href="/#contact" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg font-semibold hover:bg-spring transition-colors">
+        Schedule Consultation
+      </a>
+      <a href="tel:{{ site.phoneRaw }}" class="inline-block border-2 border-forest text-forest px-8 py-4 rounded-lg font-semibold hover:bg-forest hover:text-white transition-colors">
+        Call {{ site.phone }}
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/service-areas/lake-forest.njk
+++ b/src/service-areas/lake-forest.njk
@@ -1,0 +1,108 @@
+---
+layout: layouts/base.njk
+title: Landscape Design in Lake Forest
+description: Landscape design, garden consultation, and hardscaping in Lake Forest, CA. Serving Serrano, Baker Ranch, Portola Hills, and all Lake Forest communities.
+---
+
+{# Hero Section #}
+<section class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h1 class="text-5xl font-bold mb-8">Landscape Design in Lake Forest, CA</h1>
+    <p class="text-lg text-gray-700 mb-8">
+      Professional landscape design for Lake Forest's master-planned neighborhoods and hillside communities. We create gardens that complement your home's setting and thrive in the local climate.
+    </p>
+    <a href="/#contact" class="inline-block bg-coral text-stone px-8 py-4 rounded-full text-lg font-semibold hover:bg-sunset transition-colors">
+      Get a Free Consultation
+    </a>
+  </div>
+</section>
+
+{# Local Introduction #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-4xl">
+    <h2 class="text-4xl font-bold text-forest mb-6">Landscaping Lake Forest's Distinct Communities</h2>
+    <p class="text-gray-700 mb-6">
+      Lake Forest sits at the intersection of planned suburban living and natural oak-studded hillsides. The Serrano neighborhood, perched along the ridgeline above the 241 Toll Road, features larger lots with views and room for ambitious landscape projects. These properties often have slopes, mature oaks, and a mix of sun and shade that calls for thoughtful plant placement and terraced garden beds.
+    </p>
+    <p class="text-gray-700 mb-6">
+      Baker Ranch and the newer communities along Commercentre Drive represent a different design challenge. These homes have compact, builder-grade yards that are functional but lack personality. The opportunity here is transformation—turning a standard slab patio and strip of grass into a layered outdoor living space with raised planters, a fire feature, and strategic screening for privacy.
+    </p>
+    <p class="text-gray-700">
+      The established neighborhoods around Lake Forest Drive and Portola Hills have homes from the 1970s through 1990s with mature landscapes that are often overgrown or water-hungry. These properties benefit from a thoughtful renovation—preserving healthy specimen trees while replacing tired shrubs and lawns with drought-tolerant plantings that cut water bills and look better year-round. Steve Lytle works across all of Lake Forest, adapting designs to each neighborhood's character.
+    </p>
+  </div>
+</section>
+
+{# Services for This Area #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Our Services in Lake Forest</h2>
+    <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-leaf"></i></div>
+        <h3 class="text-xl font-bold mb-3">Garden Consultation</h3>
+        <p class="text-gray-700 mb-4">On-site assessment of your Lake Forest property covering soil, drainage, sun exposure, and existing plantings. We evaluate your HOA requirements and work within community guidelines while maximizing your yard's potential.</p>
+        <a href="/garden-consultation/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold mb-3">Plant Selection & Design</h3>
+        <p class="text-gray-700 mb-4">Plant palettes designed for Lake Forest's warm inland climate. We work around existing oaks in hillside neighborhoods and choose drought-tolerant varieties that satisfy water-use requirements while providing year-round color.</p>
+        <a href="/plant-selection/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-mountain"></i></div>
+        <h3 class="text-xl font-bold mb-3">Hardscaping</h3>
+        <p class="text-gray-700 mb-4">Custom patios, walkways, retaining walls, and fire features. Lake Forest's hillside properties benefit from terraced hardscape designs that create usable outdoor space on sloped lots.</p>
+        <a href="/hardscaping/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-carrot"></i></div>
+        <h3 class="text-xl font-bold mb-3">Vegetable Gardens</h3>
+        <p class="text-gray-700 mb-4">Custom cedar raised beds sized for Lake Forest backyards. The warm climate gives you a long growing season for tomatoes, peppers, herbs, and citrus with proper soil preparation and drip irrigation.</p>
+        <a href="/vegetable-gardens/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# FAQ Section #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-3xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Lake Forest Landscaping FAQ</h2>
+    <div class="space-y-8">
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What plants work best in Lake Forest?</h3>
+        <p class="text-gray-700">Lake Forest's inland location means warmer summers and milder winters than the coast. Heat-tolerant plants like bougainvillea, lantana, and crape myrtles thrive here. Native oaks are a signature feature of hillside neighborhoods—we design around them with compatible understory plantings like coffeeberry, toyon, and deer grass that support the local ecosystem.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">Do I need HOA approval for landscaping in Lake Forest?</h3>
+        <p class="text-gray-700">Most Lake Forest communities, including Baker Ranch and Serrano, have HOA landscape guidelines that require approval before making changes. Steve reviews your CC&Rs and submits designs that meet community standards. We've worked with many Lake Forest HOAs and understand what gets approved.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">Can I protect the oak trees on my property?</h3>
+        <p class="text-gray-700">Native coast live oaks are common in Lake Forest's hillside neighborhoods and are often protected by local ordinances. Improper grading, irrigation, or planting near their root zones can kill them. Steve designs landscapes that protect oak health by maintaining proper drainage, avoiding irrigation within the drip line, and selecting compatible companion plants.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What does a landscape consultation in Lake Forest cost?</h3>
+        <p class="text-gray-700">Contact us for current consultation rates. Steve visits your Lake Forest property to assess conditions, discuss your vision, and provide personalized recommendations. The consultation fee is applied toward your project if you move forward.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# CTA Section #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h2 class="text-4xl font-bold text-forest mb-6">Ready to Transform Your Lake Forest Yard?</h2>
+    <p class="text-lg text-gray-700 mb-8">Schedule a consultation with Steve Lytle and start designing the outdoor space you've always wanted.</p>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a href="/#contact" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg font-semibold hover:bg-spring transition-colors">
+        Schedule Consultation
+      </a>
+      <a href="tel:{{ site.phoneRaw }}" class="inline-block border-2 border-forest text-forest px-8 py-4 rounded-lg font-semibold hover:bg-forest hover:text-white transition-colors">
+        Call {{ site.phone }}
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/service-areas/mission-viejo.njk
+++ b/src/service-areas/mission-viejo.njk
@@ -1,0 +1,108 @@
+---
+layout: layouts/base.njk
+title: Landscape Design in Mission Viejo
+description: Landscape design and garden consultation in Mission Viejo, CA. Serving Lake Mission Viejo, Oso Creek, and all Mission Viejo communities.
+---
+
+{# Hero Section #}
+<section class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h1 class="text-5xl font-bold mb-8">Landscape Design in Mission Viejo, CA</h1>
+    <p class="text-lg text-gray-700 mb-8">
+      Professional landscape design for Mission Viejo's established neighborhoods. We refresh mature landscapes, design fire-safe plantings, and create outdoor living spaces that make the most of your property.
+    </p>
+    <a href="/#contact" class="inline-block bg-coral text-stone px-8 py-4 rounded-full text-lg font-semibold hover:bg-sunset transition-colors">
+      Get a Free Consultation
+    </a>
+  </div>
+</section>
+
+{# Local Introduction #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-4xl">
+    <h2 class="text-4xl font-bold text-forest mb-6">Landscaping Mission Viejo's Established Communities</h2>
+    <p class="text-gray-700 mb-6">
+      Mission Viejo was one of the largest master-planned communities in the country when it was developed in the 1960s through 1980s. Today, many of these homes have landscapes that are 30 to 50 years old—mature trees that provide welcome shade, but also overgrown foundation plantings, water-hungry turf, and irrigation systems well past their useful life. The opportunity is renovation, not starting over. A well-planned landscape refresh preserves the best of what's there while replacing what's failing.
+    </p>
+    <p class="text-gray-700 mb-6">
+      Properties near Lake Mission Viejo enjoy the community's signature amenity, and lake-adjacent homes benefit from designs that connect indoor and outdoor living with views of the water. The neighborhoods along Oso Creek Trail have a different character—backing to natural open space with sycamores, oaks, and native vegetation. Here, the design challenge is creating a garden that transitions gracefully from cultivated yard to wild landscape, using native and habitat-supporting plants along the boundary.
+    </p>
+    <p class="text-gray-700">
+      Mission Viejo's hillside neighborhoods near Saddleback Church and along the eastern ridgeline face fire safety considerations. Properties in these areas benefit from defensible space planning—fire-resistant plant selections, proper spacing, and hardscape buffers that protect the home while still creating an attractive landscape. Steve Lytle designs for all of Mission Viejo, from lakeside properties to hillside homes, working with each site's specific conditions.
+    </p>
+  </div>
+</section>
+
+{# Services for This Area #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Our Services in Mission Viejo</h2>
+    <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-leaf"></i></div>
+        <h3 class="text-xl font-bold mb-3">Garden Consultation</h3>
+        <p class="text-gray-700 mb-4">On-site assessment of your Mission Viejo property's mature landscape. We evaluate which trees and plantings to keep, which to remove, and how to refresh the garden for another 20 years of beauty and low maintenance.</p>
+        <a href="/garden-consultation/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold mb-3">Plant Selection & Design</h3>
+        <p class="text-gray-700 mb-4">Updated plant palettes for Mission Viejo's inland climate. We replace water-hungry species with drought-tolerant alternatives that look better and cost less to maintain, selecting fire-resistant varieties for hillside properties near open space.</p>
+        <a href="/plant-selection/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-tint"></i></div>
+        <h3 class="text-xl font-bold mb-3">Irrigation Systems</h3>
+        <p class="text-gray-700 mb-4">Irrigation retrofits and new system design for Mission Viejo properties. Many older homes still run original spray systems from the 1970s. Modern drip irrigation and smart controllers can cut water use dramatically while keeping plants healthier.</p>
+        <a href="/irrigation-systems/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-mountain"></i></div>
+        <h3 class="text-xl font-bold mb-3">Hardscaping</h3>
+        <p class="text-gray-700 mb-4">Patios, walkways, fire pits, and retaining walls for Mission Viejo's moderate to large lots. Hillside properties benefit from terraced designs that create usable outdoor space on slopes while managing drainage.</p>
+        <a href="/hardscaping/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# FAQ Section #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-3xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Mission Viejo Landscaping FAQ</h2>
+    <div class="space-y-8">
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">How do I update a 1970s landscape in Mission Viejo?</h3>
+        <p class="text-gray-700">Start with a consultation to assess what's worth keeping. Healthy mature trees provide shade and structure that takes decades to replace—we design around them. The typical renovation involves removing overgrown shrubs, replacing lawn with drought-tolerant plantings, updating irrigation to drip, and adding hardscape features like patios or fire pits that modernize the outdoor space.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What fire-safe landscaping is recommended in Mission Viejo?</h3>
+        <p class="text-gray-700">Properties near open space should maintain defensible space per OCFA guidelines. This means fire-resistant plants in the first 5 feet from the house (succulents, ground-hugging shrubs), well-spaced plantings in the next 30 feet, and thinned vegetation beyond that. We design landscapes that meet fire safety requirements while still looking beautiful and providing privacy.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">Does Mission Viejo have HOA landscape requirements?</h3>
+        <p class="text-gray-700">Many Mission Viejo neighborhoods have active HOAs with landscape guidelines. Requirements vary by community—some restrict plant heights, fence styles, or front yard materials. Steve reviews your specific HOA rules before designing and submits plans that comply with community standards.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What does a landscape consultation in Mission Viejo cost?</h3>
+        <p class="text-gray-700">Contact us for current consultation rates. Steve visits your Mission Viejo property to assess conditions, discuss your vision, and provide personalized recommendations. The consultation fee is applied toward your project if you move forward.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# CTA Section #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h2 class="text-4xl font-bold text-forest mb-6">Ready to Transform Your Mission Viejo Yard?</h2>
+    <p class="text-lg text-gray-700 mb-8">Schedule a consultation with Steve Lytle and start designing the outdoor space you've always wanted.</p>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a href="/#contact" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg font-semibold hover:bg-spring transition-colors">
+        Schedule Consultation
+      </a>
+      <a href="tel:{{ site.phoneRaw }}" class="inline-block border-2 border-forest text-forest px-8 py-4 rounded-lg font-semibold hover:bg-forest hover:text-white transition-colors">
+        Call {{ site.phone }}
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/service-areas/newport-beach.njk
+++ b/src/service-areas/newport-beach.njk
@@ -1,0 +1,108 @@
+---
+layout: layouts/base.njk
+title: Landscape Design in Newport Beach
+description: Landscape design and garden consultation in Newport Beach, CA. Serving Corona del Mar, Newport Coast, Harbor View Hills, and Balboa Peninsula.
+---
+
+{# Hero Section #}
+<section class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h1 class="text-5xl font-bold mb-8">Landscape Design in Newport Beach, CA</h1>
+    <p class="text-lg text-gray-700 mb-8">
+      Professional landscape design for Newport Beach's coastal properties. Salt-tolerant plantings, outdoor entertaining spaces, and Mediterranean gardens designed for the ocean climate.
+    </p>
+    <a href="/#contact" class="inline-block bg-coral text-stone px-8 py-4 rounded-full text-lg font-semibold hover:bg-sunset transition-colors">
+      Get a Free Consultation
+    </a>
+  </div>
+</section>
+
+{# Local Introduction #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-4xl">
+    <h2 class="text-4xl font-bold text-forest mb-6">Landscaping Newport Beach's Coastal Properties</h2>
+    <p class="text-gray-700 mb-6">
+      Newport Beach presents unique landscaping challenges and opportunities shaped by the ocean. Corona del Mar's hillside homes and village cottages demand different approaches—the hillside properties above Inspiration Point have room for layered Mediterranean gardens with ocean views, while the village's smaller lots call for intimate courtyard designs and vertical plantings that maximize every inch. Salt air exposure is a constant consideration, requiring plants that tolerate coastal conditions without sacrificing beauty.
+    </p>
+    <p class="text-gray-700 mb-6">
+      Newport Coast and the communities along San Joaquin Hills Road feature some of Orange County's most substantial residential properties. These larger lots support ambitious landscape projects—resort-style outdoor living rooms, specimen trees, extensive hardscape with natural stone, and integrated lighting that transforms the garden after dark. The hillside terrain requires careful drainage planning and erosion-resistant plantings, particularly on slopes facing the coast.
+    </p>
+    <p class="text-gray-700">
+      Harbor View Hills and the neighborhoods along the Back Bay offer a different setting—flatter lots with proximity to the Upper Newport Bay Ecological Reserve. Here, the design opportunity is creating gardens that complement the natural surroundings with native and habitat-supporting plantings. The Balboa Peninsula and Lido Isle present the most constrained spaces, where creative hardscape and container gardens turn compact outdoor areas into functional retreats. Steve Lytle designs for all of Newport Beach, matching the garden to the setting.
+    </p>
+  </div>
+</section>
+
+{# Services for This Area #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Our Services in Newport Beach</h2>
+    <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-leaf"></i></div>
+        <h3 class="text-xl font-bold mb-3">Garden Consultation</h3>
+        <p class="text-gray-700 mb-4">Comprehensive property assessment evaluating salt exposure, wind patterns, soil conditions, and drainage. Newport Beach gardens face specific coastal pressures that require expert planning from the start.</p>
+        <a href="/garden-consultation/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold mb-3">Plant Selection & Design</h3>
+        <p class="text-gray-700 mb-4">Salt-tolerant and coastal-adapted plant palettes. We select Mediterranean, subtropical, and native species that thrive in Newport Beach's ocean climate—plants that handle salt spray, onshore winds, and morning fog while looking lush year-round.</p>
+        <a href="/plant-selection/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-mountain"></i></div>
+        <h3 class="text-xl font-bold mb-3">Hardscaping</h3>
+        <p class="text-gray-700 mb-4">Natural stone patios, outdoor kitchens, fire features, and retaining walls. Newport Beach properties often need hardscape that extends living space and handles the slope, salt, and drainage demands of coastal terrain.</p>
+        <a href="/hardscaping/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-lightbulb"></i></div>
+        <h3 class="text-xl font-bold mb-3">Landscape Lighting</h3>
+        <p class="text-gray-700 mb-4">Low-voltage LED lighting designed for Newport Beach's outdoor entertaining culture. Path lighting, uplighting for specimen trees, and architectural accent lighting that extends your garden's beauty into the evening hours.</p>
+        <a href="/landscape-lighting/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# FAQ Section #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-3xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Newport Beach Landscaping FAQ</h2>
+    <div class="space-y-8">
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What plants handle the salt air in Newport Beach?</h3>
+        <p class="text-gray-700">Salt-tolerant species are essential for properties near the coast. Agave, New Zealand flax, rosemary, pittosporum, and coastal sage scrub natives all handle salt spray well. For color, society garlic, kangaroo paw, and seaside daisy are reliable performers. We select plants based on your property's specific exposure—homes on the bluff face different conditions than homes sheltered behind the peninsula.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">Do I need permits for hardscaping in Newport Beach?</h3>
+        <p class="text-gray-700">Newport Beach requires permits for structures, significant grading, and work near the coastal zone. Properties in the Coastal Zone have additional review requirements through the California Coastal Commission. Steve navigates the permitting process as part of every project and designs with local regulations in mind from the start.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">How do I landscape a hillside property in Corona del Mar?</h3>
+        <p class="text-gray-700">Hillside properties need erosion control, proper drainage, and deep-rooted plantings that stabilize slopes. We use a combination of retaining walls, terraced planting beds, and groundcovers like trailing rosemary and native dudleya that hold soil while providing coastal character. Drainage design is critical to prevent runoff from damaging the slope or neighboring properties.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What does a landscape consultation in Newport Beach cost?</h3>
+        <p class="text-gray-700">Contact us for current consultation rates. Steve visits your Newport Beach property to assess conditions, discuss your vision, and provide personalized recommendations. The consultation fee is applied toward your project if you move forward.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# CTA Section #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h2 class="text-4xl font-bold text-forest mb-6">Ready to Transform Your Newport Beach Garden?</h2>
+    <p class="text-lg text-gray-700 mb-8">Schedule a consultation with Steve Lytle and start designing the outdoor space you've always wanted.</p>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a href="/#contact" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg font-semibold hover:bg-spring transition-colors">
+        Schedule Consultation
+      </a>
+      <a href="tel:{{ site.phoneRaw }}" class="inline-block border-2 border-forest text-forest px-8 py-4 rounded-lg font-semibold hover:bg-forest hover:text-white transition-colors">
+        Call {{ site.phone }}
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/service-areas/rancho-santa-margarita.njk
+++ b/src/service-areas/rancho-santa-margarita.njk
@@ -1,0 +1,108 @@
+---
+layout: layouts/base.njk
+title: Landscape Design in Rancho Santa Margarita
+description: Landscape design and garden consultation in Rancho Santa Margarita, CA. Serving Dove Canyon, Robinson Ranch, and Trabuco Canyon.
+---
+
+{# Hero Section #}
+<section class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h1 class="text-5xl font-bold mb-8">Landscape Design in Rancho Santa Margarita, CA</h1>
+    <p class="text-lg text-gray-700 mb-8">
+      Professional landscape design for Rancho Santa Margarita and the surrounding canyon communities. Fire-safe, water-efficient gardens designed for the wildland-urban interface.
+    </p>
+    <a href="/#contact" class="inline-block bg-coral text-stone px-8 py-4 rounded-full text-lg font-semibold hover:bg-sunset transition-colors">
+      Get a Free Consultation
+    </a>
+  </div>
+</section>
+
+{# Local Introduction #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-4xl">
+    <h2 class="text-4xl font-bold text-forest mb-6">Landscaping Rancho Santa Margarita's Canyon Communities</h2>
+    <p class="text-gray-700 mb-6">
+      Rancho Santa Margarita sits at the transition between suburban Orange County and the wild terrain of the Santa Ana Mountains. The city center and neighborhoods along Antonio Parkway feature well-maintained planned communities from the 1990s with moderate lots and active HOAs. These properties typically have builder-installed landscapes that are now 25 to 30 years old—still functional but ready for a refresh that adds personality and cuts water use.
+    </p>
+    <p class="text-gray-700 mb-6">
+      The canyon communities tell a different story. Robinson Ranch, Dove Canyon, and the neighborhoods along Plano Trabuco sit closer to the wildland interface, with views of the foothills and direct exposure to fire risk. Landscaping these properties requires balancing aesthetics with safety—fire-resistant plant choices, defensible space around structures, and hardscape buffers that protect the home without making the yard feel like a barren zone. Done well, fire-safe landscaping looks intentional and beautiful, not like a compromise.
+    </p>
+    <p class="text-gray-700">
+      Trabuco Canyon, just east of RSM, offers larger lots with a more rural character. These semi-rural properties have room for ambitious projects—native habitat gardens, extensive hardscape, and productive vegetable gardens. The canyon microclimate runs warmer in summer and cooler in winter than the coast, which affects plant selection. Steve Lytle designs for all of Rancho Santa Margarita and the surrounding canyon communities, adapting to each property's terrain, exposure, and HOA requirements.
+    </p>
+  </div>
+</section>
+
+{# Services for This Area #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Our Services in Rancho Santa Margarita</h2>
+    <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-leaf"></i></div>
+        <h3 class="text-xl font-bold mb-3">Garden Consultation</h3>
+        <p class="text-gray-700 mb-4">On-site assessment covering fire risk, HOA requirements, soil conditions, and existing plantings. RSM properties near the wildland interface need expert evaluation of defensible space and fire-resistant landscaping strategies.</p>
+        <a href="/garden-consultation/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold mb-3">Plant Selection & Design</h3>
+        <p class="text-gray-700 mb-4">Fire-resistant and drought-tolerant plant palettes for RSM's inland canyon climate. We select species that handle the summer heat, reduce fire risk near structures, and still provide the color and texture that make a garden inviting.</p>
+        <a href="/plant-selection/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-mountain"></i></div>
+        <h3 class="text-xl font-bold mb-3">Hardscaping</h3>
+        <p class="text-gray-700 mb-4">Patios, retaining walls, fire pits, and walkways. In canyon communities, hardscape serves double duty—creating outdoor living space and providing non-combustible buffers between structures and vegetation in fire-prone areas.</p>
+        <a href="/hardscaping/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-tint"></i></div>
+        <h3 class="text-xl font-bold mb-3">Irrigation Systems</h3>
+        <p class="text-gray-700 mb-4">Efficient drip irrigation and smart controllers for RSM's warm inland climate. Proper irrigation keeps fire-resistant plantings healthy while minimizing water waste in a region where summer temperatures regularly exceed 90 degrees.</p>
+        <a href="/irrigation-systems/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# FAQ Section #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-3xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Rancho Santa Margarita Landscaping FAQ</h2>
+    <div class="space-y-8">
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What fire-safe plants work in Rancho Santa Margarita?</h3>
+        <p class="text-gray-700">Fire-resistant plants for the RSM area include succulents like aloe and agave, low-growing groundcovers like creeping thyme and dymondia, and well-spaced shrubs like toyon and lemonade berry. Avoid highly flammable species like juniper, pampas grass, and Italian cypress near structures. The key is proper spacing and maintenance—even fire-resistant plants become hazardous when overgrown or dried out.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">Do RSM HOAs allow landscape changes?</h3>
+        <p class="text-gray-700">Most RSM communities require architectural review before landscape modifications. Requirements vary—Dove Canyon has different guidelines than the neighborhoods along Antonio Parkway. Steve reviews your specific CC&Rs before designing and submits HOA-ready plans that get approved efficiently.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">How do I landscape a slope near the canyon?</h3>
+        <p class="text-gray-700">Canyon-adjacent slopes need erosion control, fire safety, and drought tolerance. We use deep-rooted native plants like California buckwheat, purple sage, and deer grass that stabilize slopes while providing fire resistance. Jute netting and proper grading prevent erosion during winter rains. The goal is a slope that looks like a natural extension of the canyon landscape, not a neglected patch.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What does a landscape consultation in Rancho Santa Margarita cost?</h3>
+        <p class="text-gray-700">Contact us for current consultation rates. Steve visits your RSM property to assess conditions, discuss your vision, and provide personalized recommendations. The consultation fee is applied toward your project if you move forward.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# CTA Section #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h2 class="text-4xl font-bold text-forest mb-6">Ready to Transform Your Rancho Santa Margarita Yard?</h2>
+    <p class="text-lg text-gray-700 mb-8">Schedule a consultation with Steve Lytle and start designing the outdoor space you've always wanted.</p>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a href="/#contact" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg font-semibold hover:bg-spring transition-colors">
+        Schedule Consultation
+      </a>
+      <a href="tel:{{ site.phoneRaw }}" class="inline-block border-2 border-forest text-forest px-8 py-4 rounded-lg font-semibold hover:bg-forest hover:text-white transition-colors">
+        Call {{ site.phone }}
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/service-areas/santa-ana.njk
+++ b/src/service-areas/santa-ana.njk
@@ -1,0 +1,108 @@
+---
+layout: layouts/base.njk
+title: Landscape Design in Santa Ana
+description: Landscape design and garden consultation in Santa Ana, CA. Serving Floral Park, Morrison Park, South Coast Metro, and all Santa Ana neighborhoods.
+---
+
+{# Hero Section #}
+<section class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h1 class="text-5xl font-bold mb-8">Landscape Design in Santa Ana, CA</h1>
+    <p class="text-lg text-gray-700 mb-8">
+      Professional landscape design for Santa Ana's diverse neighborhoods. From Floral Park's historic homes to compact urban lots, we create gardens that maximize your outdoor space and reduce water use.
+    </p>
+    <a href="/#contact" class="inline-block bg-coral text-stone px-8 py-4 rounded-full text-lg font-semibold hover:bg-sunset transition-colors">
+      Get a Free Consultation
+    </a>
+  </div>
+</section>
+
+{# Local Introduction #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-4xl">
+    <h2 class="text-4xl font-bold text-forest mb-6">Landscaping Santa Ana's Neighborhoods</h2>
+    <p class="text-gray-700 mb-6">
+      Santa Ana's Floral Park neighborhood is one of Orange County's hidden gems for landscape design. The historic district features Craftsman bungalows, Spanish Colonial Revival homes, and Tudor-style residences from the 1920s through 1940s, many with deep lots and mature trees. These properties call for period-appropriate garden designs—cottage gardens for Craftsman homes, tiled courtyard gardens for Spanish Revival, and formal hedging for Tudors. The annual Floral Park Home & Garden Tour puts these landscapes on display, and we design gardens worthy of the showcase.
+    </p>
+    <p class="text-gray-700 mb-6">
+      Morrison Park and the neighborhoods near Santa Ana College feature mid-century homes with moderate lots where smart design makes a big difference. These properties often have aging landscapes with water-hungry lawns and overgrown shrubs that are ready for transformation. A drought-tolerant renovation can cut water bills in half while creating a more attractive and lower-maintenance yard. Multigenerational households are common in Santa Ana, and we design outdoor spaces that accommodate larger families—shade structures, extended patios, and productive vegetable gardens that bring families outside together.
+    </p>
+    <p class="text-gray-700">
+      The areas near South Coast Metro and along the Tustin border feature newer townhomes and condos alongside established single-family homes. These properties range from small courtyard gardens to full residential lots. Steve Lytle designs for all of Santa Ana's neighborhoods, creating landscapes that fit the home's style, the family's needs, and the local climate.
+    </p>
+  </div>
+</section>
+
+{# Services for This Area #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Our Services in Santa Ana</h2>
+    <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-leaf"></i></div>
+        <h3 class="text-xl font-bold mb-3">Garden Consultation</h3>
+        <p class="text-gray-700 mb-4">On-site property assessment covering soil quality, drainage, sun exposure, and existing plantings. In Santa Ana's historic neighborhoods, we also evaluate how to design gardens that complement period architecture.</p>
+        <a href="/garden-consultation/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold mb-3">Plant Selection & Design</h3>
+        <p class="text-gray-700 mb-4">Drought-tolerant plant palettes that bring color and texture to Santa Ana gardens year-round. We match plants to your home's architectural style and your family's needs—shade trees for outdoor gathering, fragrant hedges for privacy, and productive edibles for the kitchen.</p>
+        <a href="/plant-selection/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-carrot"></i></div>
+        <h3 class="text-xl font-bold mb-3">Vegetable Gardens</h3>
+        <p class="text-gray-700 mb-4">Custom cedar raised beds for Santa Ana's warm growing climate. The inland heat is perfect for tomatoes, chiles, squash, and herbs. We build raised beds with proper soil mix, drip irrigation, and wire mesh pest barriers that make home growing easy and productive.</p>
+        <a href="/vegetable-gardens/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-hand-holding-water"></i></div>
+        <h3 class="text-xl font-bold mb-3">Soil Health</h3>
+        <p class="text-gray-700 mb-4">Santa Ana's older neighborhoods often have compacted, depleted soils from decades of use. Proper soil amendment and preparation is essential before planting. We test your soil and build a custom amendment plan to give new plantings the best start.</p>
+        <a href="/soil-health/" class="text-forest font-semibold hover:text-lime transition-colors">Learn more &rarr;</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# FAQ Section #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-3xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">Santa Ana Landscaping FAQ</h2>
+    <div class="space-y-8">
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What plants work best in Santa Ana's climate?</h3>
+        <p class="text-gray-700">Santa Ana sits inland with warm summers and mild winters. Heat-loving plants like bougainvillea, lantana, crape myrtle, and red yucca thrive here. For shade, tipu trees and Chinese elm grow quickly. California natives like toyon, white sage, and buckwheat are excellent low-water choices that support local pollinators and wildlife.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">How do I landscape a historic home in Floral Park?</h3>
+        <p class="text-gray-700">Floral Park homes have specific architectural styles that benefit from period-appropriate gardens. Craftsman homes pair well with cottage-style plantings—roses, hydrangeas, and ornamental grasses. Spanish Revival homes call for tiled accents, courtyard designs, and Mediterranean plants like olive trees, lavender, and bougainvillea. Steve designs gardens that enhance the home's historic character while meeting modern water-efficiency standards.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">Are there water rebates available for Santa Ana residents?</h3>
+        <p class="text-gray-700">Yes, Santa Ana Water Department and the Municipal Water District of Orange County periodically offer rebates for turf removal and water-efficient landscaping upgrades. We design with rebate eligibility in mind and can help you understand what programs are currently available for your property.</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-bold text-forest mb-2">What does a landscape consultation in Santa Ana cost?</h3>
+        <p class="text-gray-700">Contact us for current consultation rates. Steve visits your Santa Ana property to assess conditions, discuss your vision, and provide personalized recommendations. The consultation fee is applied toward your project if you move forward.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# CTA Section #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h2 class="text-4xl font-bold text-forest mb-6">Ready to Transform Your Santa Ana Yard?</h2>
+    <p class="text-lg text-gray-700 mb-8">Schedule a consultation with Steve Lytle and start designing the outdoor space you've always wanted.</p>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a href="/#contact" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg font-semibold hover:bg-spring transition-colors">
+        Schedule Consultation
+      </a>
+      <a href="tel:{{ site.phoneRaw }}" class="inline-block border-2 border-forest text-forest px-8 py-4 rounded-lg font-semibold hover:bg-forest hover:text-white transition-colors">
+        Call {{ site.phone }}
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/vegetable-gardens.njk
+++ b/src/vegetable-gardens.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/base.njk
 title: Vegetable Gardens
-description: Custom raised bed and vegetable garden design in Orange County. Cedar veggie boxes, soil preparation, and expert growing guidance from a certified horticulturist.
+description: Custom raised bed and vegetable garden design in Orange County. Cedar veggie boxes, soil prep, and growing guidance from a certified horticulturist.
 ---
 
 {# Hero Section #}


### PR DESCRIPTION
## Summary
- Add city landing pages for Lake Forest, Irvine, Costa Mesa, Newport Beach, Santa Ana, Mission Viejo, and Rancho Santa Margarita (unique local content per city)
- Update homepage heading to "Some of the Areas We Serve" and convert all city names to links
- Add Rancho Santa Margarita to structured data areaServed
- Trim Fullerton meta description (169→146 chars) and veggie gardens (162→148 chars) per Screaming Frog findings

## Test plan
- [ ] `npm run build` succeeds (29 pages)
- [ ] All 7 new pages render at correct trailing-slash URLs
- [ ] Sitemap includes all 11 service area pages
- [ ] Footer shows all 11 service areas
- [ ] Homepage heading says "Some of the Areas We Serve"
- [ ] All homepage city entries are links (no plain text spans)
- [ ] Rancho Santa Margarita appears in homepage list and footer
- [ ] No broken internal links

🤖 Generated with [Claude Code](https://claude.com/claude-code)