### PR TITLE
Migrate blog URLs from /content/posts/ to /blog/

### DIFF
--- a/src/blog-redirects.njk
+++ b/src/blog-redirects.njk
@@ -1,0 +1,20 @@
+---
+pagination:
+  data: collections.posts
+  size: 1
+  alias: post
+permalink: "/content/posts/{{ post.fileSlug }}/"
+eleventyExcludeFromCollections: true
+---
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url={{ post.url }}">
+  <link rel="canonical" href="{{ site.url }}{{ post.url }}">
+  <title>Redirecting...</title>
+</head>
+<body>
+  <p>This page has moved to <a href="{{ post.url }}">{{ post.url }}</a>.</p>
+</body>
+</html>

--- a/src/content/posts/how-to-plant-a-tree.md
+++ b/src/content/posts/how-to-plant-a-tree.md
@@ -1,7 +1,7 @@
 ---
 layout: layouts/post.njk
 title: Professional Guide to Tree Planting
-description: Learn professional techniques for proper tree planting from Orange County's premier horticulturist. Expert guidance on hole depth, root care, and soil preparation.
+description: Learn professional techniques for proper tree planting from Orange County's premier horticulturist. Expert guidance on hole depth, root care, and soil prep.
 date: 2025-01-30
 image: /assets/images/tree-planting-guide.webp
 ---

--- a/src/content/posts/posts.json
+++ b/src/content/posts/posts.json
@@ -1,0 +1,3 @@
+{
+  "permalink": "/blog/{{ page.fileSlug }}/"
+}

--- a/src/index.njk
+++ b/src/index.njk
@@ -476,7 +476,7 @@ description: Expert landscape design and garden consultation in Orange County by
           <span><i class="far fa-calendar mr-1"></i> Jan 10, 2024</span>
           <span><i class="far fa-clock mr-1"></i> 5 min read</span>
         </div>
-        <a href="/content/posts/water-conservation/" class="inline-flex items-center text-forest hover:text-lime transition-colors">
+        <a href="/blog/water-conservation/" class="inline-flex items-center text-forest hover:text-lime transition-colors">
           Dive into the Article
           <i class="fas fa-arrow-right ml-2"></i>
         </a>
@@ -494,7 +494,7 @@ description: Expert landscape design and garden consultation in Orange County by
           </p>
           <div class="flex items-center justify-between text-sm">
             <span class="text-gray-500">Jan 31, 2025</span>
-            <a href="/content/posts/basic-landscape-design/" class="text-forest hover:text-lime transition-colors">Explore landscape design basics</a>
+            <a href="/blog/basic-landscape-design/" class="text-forest hover:text-lime transition-colors">Explore landscape design basics</a>
           </div>
         </div>
       </article>
@@ -508,7 +508,7 @@ description: Expert landscape design and garden consultation in Orange County by
           </p>
           <div class="flex items-center justify-between text-sm">
             <span class="text-gray-500">Jan 30, 2025</span>
-            <a href="/content/posts/how-to-plant-a-tree/" class="text-forest hover:text-lime transition-colors">Get started with tree planting</a>
+            <a href="/blog/how-to-plant-a-tree/" class="text-forest hover:text-lime transition-colors">Get started with tree planting</a>
           </div>
         </div>
       </article>
@@ -522,7 +522,7 @@ description: Expert landscape design and garden consultation in Orange County by
           </p>
           <div class="flex items-center justify-between text-sm">
             <span class="text-gray-500">Dec 28, 2024</span>
-            <a href="/content/posts/native-plants/" class="text-forest hover:text-lime transition-colors">Discover how to use native plants</a>
+            <a href="/blog/native-plants/" class="text-forest hover:text-lime transition-colors">Discover how to use native plants</a>
           </div>
         </div>
       </article>
@@ -536,7 +536,7 @@ description: Expert landscape design and garden consultation in Orange County by
           </p>
           <div class="flex items-center justify-between text-sm">
             <span class="text-gray-500">Dec 15, 2024</span>
-            <a href="/content/posts/hardscaping-trends/" class="text-forest hover:text-lime transition-colors">Read the latest trends</a>
+            <a href="/blog/hardscaping-trends/" class="text-forest hover:text-lime transition-colors">Read the latest trends</a>
           </div>
         </div>
       </article>
@@ -550,7 +550,7 @@ description: Expert landscape design and garden consultation in Orange County by
           </p>
           <div class="flex items-center justify-between text-sm">
             <span class="text-gray-500">Dec 5, 2024</span>
-            <a href="/content/posts/maintenance/" class="text-forest hover:text-lime transition-colors">Learn how to maintain your garden</a>
+            <a href="/blog/maintenance/" class="text-forest hover:text-lime transition-colors">Learn how to maintain your garden</a>
           </div>
         </div>
       </article>


### PR DESCRIPTION
## Summary

- Blog post URLs moved from `/content/posts/[slug]/` to `/blog/[slug]/` via directory data file permalink
- Client-side redirects at old URLs (`<meta http-equiv="refresh">` + `rel="canonical"`) so existing links and Google index transfer cleanly
- Homepage blog links updated to new `/blog/` paths
- Tree planting meta description trimmed from 163 to 156 chars (under 160 limit)

## Test plan

- [ ] `npm run build` succeeds
- [ ] Blog posts render at `/blog/[slug]/` URLs
- [ ] Old `/content/posts/[slug]/` URLs serve redirect pages
- [ ] Sitemap shows `/blog/` URLs only
- [ ] Homepage blog links point to `/blog/`
- [ ] `how-to-plant-a-tree` meta description under 160 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)