### PR TITLE
Trim contact form + add Selected Work to Newport Beach

### DIFF
--- a/src/assets/js/application.js
+++ b/src/assets/js/application.js
@@ -10,3 +10,6 @@ window.Stimulus = application;
 // Import and register controllers
 import MobileNavController from "./controllers/mobile_nav_controller.js";
 application.register("mobile-nav", MobileNavController);
+
+import ContactFormController from "./controllers/contact_form_controller.js";
+application.register("contact-form", ContactFormController);

--- a/src/assets/js/controllers/contact_form_controller.js
+++ b/src/assets/js/controllers/contact_form_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["phone", "email", "error"];
+
+  validate(event) {
+    const phone = this.phoneTarget.value.trim();
+    const email = this.emailTarget.value.trim();
+
+    if (phone === "" && email === "") {
+      event.preventDefault();
+      this.errorTarget.classList.remove("hidden");
+      this.phoneTarget.focus();
+      return;
+    }
+
+    this.errorTarget.classList.add("hidden");
+  }
+}

--- a/src/index.njk
+++ b/src/index.njk
@@ -571,82 +571,88 @@ description: Expert landscape design and garden consultation in Orange County by
         <p class="text-gray-600">Transform your outdoor space with our expertise</p>
       </div>
 
-      <form action="https://api.web3forms.com/submit" method="POST" class="space-y-6">
+      <form action="https://api.web3forms.com/submit" method="POST" class="space-y-6" data-controller="contact-form" data-action="submit->contact-form#validate">
         {# Hidden fields for Web3Forms integration #}
         <input type="hidden" name="access_key" value="{{ site.forms.web3formsKey }}">
         <input type="hidden" name="subject" value="New Contact Form Submission">
         <input type="hidden" name="from_name" value="{{ site.name }}">
         <input type="hidden" name="redirect" value="{{ site.url }}/thank-you/">
 
-        {# Name and Phone Fields #}
-        <div class="grid md:grid-cols-2 gap-6">
-          <div>
-            <label for="name" class="block text-sm font-medium text-gray-700">Your Name *</label>
-            <input type="text" id="name" name="name" required placeholder="John Doe" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
-          </div>
-          <div>
-            <label for="phone" class="block text-sm font-medium text-gray-700">Phone Number *</label>
-            <input type="tel" id="phone" name="phone" required placeholder="(123) 456-7890" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
-          </div>
-        </div>
-
-        {# Email Field #}
+        {# Name (required) #}
         <div>
-          <label for="email" class="block text-sm font-medium text-gray-700">Email Address *</label>
-          <input type="email" id="email" name="email" required placeholder="example@example.com" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+          <label for="name" class="block text-sm font-medium text-gray-700">Your Name *</label>
+          <input type="text" id="name" name="name" required placeholder="John Doe" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
         </div>
 
-        {# Project Address #}
+        {# Phone or Email (at least one required, validated client-side) #}
         <div>
-          <label for="address" class="block text-sm font-medium text-gray-700">Project Address *</label>
-          <input type="text" id="address" name="address" required placeholder="123 Main Street" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
-        </div>
-
-        {# City and ZIP Fields #}
-        <div class="grid grid-cols-2 gap-6">
-          <div>
-            <label for="city" class="block text-sm font-medium text-gray-700">City *</label>
-            <input type="text" id="city" name="city" required placeholder="City" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+          <div class="grid md:grid-cols-2 gap-6">
+            <div>
+              <label for="phone" class="block text-sm font-medium text-gray-700">Phone Number</label>
+              <input type="tel" id="phone" name="phone" data-contact-form-target="phone" placeholder="(123) 456-7890" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+            </div>
+            <div>
+              <label for="email" class="block text-sm font-medium text-gray-700">Email Address</label>
+              <input type="email" id="email" name="email" data-contact-form-target="email" placeholder="example@example.com" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+            </div>
           </div>
-          <div>
-            <label for="zip" class="block text-sm font-medium text-gray-700">ZIP Code *</label>
-            <input type="text" id="zip" name="zip" required placeholder="12345" pattern="\d*" maxlength="5" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
-          </div>
+          <p class="mt-2 text-sm text-gray-500">Provide a phone or email — whichever you prefer. We'll use it to follow up.</p>
+          <p data-contact-form-target="error" class="mt-2 text-sm text-red-600 hidden" role="alert">Please provide either a phone number or an email address.</p>
         </div>
 
-        {# Service Type #}
-        <div>
-          <label for="service" class="block text-sm font-medium text-gray-700">Service Type *</label>
-          <select id="service" name="service" required class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
-            <option value="" disabled selected>Select a service</option>
-            <option value="Landscape Design">Landscape Design</option>
-            <option value="Landscape Installation">Landscape Installation</option>
-            <option value="Irrigation & Drainage">Irrigation & Drainage</option>
-            <option value="Landscape Lighting">Landscape Lighting</option>
-            <option value="Vegetable Gardens">Vegetable Gardens</option>
-            <option value="Other Services">Other Services</option>
-          </select>
-        </div>
-
-        {# How did you find us #}
-        <div>
-          <label for="referral_source" class="block text-sm font-medium text-gray-700">How did you find us? *</label>
-          <select id="referral_source" name="referral_source" required class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
-            <option value="" disabled selected>Please select an option</option>
-            <option value="Google search">Google search</option>
-            <option value="The Homemag">The Homemag</option>
-            <option value="Craigslist ad">Craigslist ad</option>
-            <option value="Referral from a friend">Referral from a friend</option>
-            <option value="Yelp">Yelp</option>
-            <option value="Houzz">Houzz</option>
-          </select>
-        </div>
-
-        {# Project Details #}
+        {# Project Details (required) #}
         <div>
           <label for="message" class="block text-sm font-medium text-gray-700">Project Details *</label>
           <textarea id="message" name="message" required rows="4" placeholder="Tell us about your project" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest"></textarea>
         </div>
+
+        {# Optional fields below — helps us prep but not required #}
+        <details class="rounded-lg bg-gray-50 p-4">
+          <summary class="cursor-pointer text-sm font-medium text-forest">Add project details (optional — speeds up our reply)</summary>
+          <div class="mt-4 space-y-6">
+            <div>
+              <label for="address" class="block text-sm font-medium text-gray-700">Project Address</label>
+              <input type="text" id="address" name="address" placeholder="123 Main Street" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+            </div>
+
+            <div class="grid grid-cols-2 gap-6">
+              <div>
+                <label for="city" class="block text-sm font-medium text-gray-700">City</label>
+                <input type="text" id="city" name="city" placeholder="City" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+              </div>
+              <div>
+                <label for="zip" class="block text-sm font-medium text-gray-700">ZIP Code</label>
+                <input type="text" id="zip" name="zip" placeholder="12345" pattern="\d*" maxlength="5" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+              </div>
+            </div>
+
+            <div>
+              <label for="service" class="block text-sm font-medium text-gray-700">Service Type</label>
+              <select id="service" name="service" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+                <option value="" selected>Not sure yet</option>
+                <option value="Landscape Design">Landscape Design</option>
+                <option value="Landscape Installation">Landscape Installation</option>
+                <option value="Irrigation & Drainage">Irrigation & Drainage</option>
+                <option value="Landscape Lighting">Landscape Lighting</option>
+                <option value="Vegetable Gardens">Vegetable Gardens</option>
+                <option value="Other Services">Other Services</option>
+              </select>
+            </div>
+
+            <div>
+              <label for="referral_source" class="block text-sm font-medium text-gray-700">How did you find us?</label>
+              <select id="referral_source" name="referral_source" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+                <option value="" selected>Prefer not to say</option>
+                <option value="Google search">Google search</option>
+                <option value="The Homemag">The Homemag</option>
+                <option value="Craigslist ad">Craigslist ad</option>
+                <option value="Referral from a friend">Referral from a friend</option>
+                <option value="Yelp">Yelp</option>
+                <option value="Houzz">Houzz</option>
+              </select>
+            </div>
+          </div>
+        </details>
 
         {# hCaptcha #}
         <div class="h-captcha" data-sitekey="50b2fe65-b00b-4b9e-ad62-3ba471098be2"></div>

--- a/src/service-areas/newport-beach.njk
+++ b/src/service-areas/newport-beach.njk
@@ -25,7 +25,7 @@ description: Landscape design and garden consultation in Newport Beach, CA. Serv
       Newport Beach presents unique landscaping challenges and opportunities shaped by the ocean. Corona del Mar's hillside homes and village cottages demand different approaches—the hillside properties above Inspiration Point have room for layered Mediterranean gardens with ocean views, while the village's smaller lots call for intimate courtyard designs and vertical plantings that maximize every inch. Salt air exposure is a constant consideration, requiring plants that tolerate coastal conditions without sacrificing beauty.
     </p>
     <p class="text-gray-700 mb-6">
-      Newport Coast and the communities along San Joaquin Hills Road feature some of Orange County's most substantial residential properties. These larger lots support ambitious landscape projects—resort-style outdoor living rooms, specimen trees, extensive hardscape with natural stone, and integrated lighting that transforms the garden after dark. The hillside terrain requires careful drainage planning and erosion-resistant plantings, particularly on slopes facing the coast.
+      Newport Coast and the communities along San Joaquin Hills Road feature some of Orange County's most substantial residential properties. These larger lots support ambitious landscape projects—resort-style outdoor living rooms, specimen trees, extensive <a href="/hardscaping/" class="text-forest underline hover:text-lime">hardscape</a> with natural stone, and integrated <a href="/landscape-lighting/" class="text-forest underline hover:text-lime">lighting</a> that transforms the garden after dark. The hillside terrain requires careful <a href="/irrigation-systems/" class="text-forest underline hover:text-lime">drainage planning</a> and erosion-resistant plantings, particularly on slopes facing the coast.
     </p>
     <p class="text-gray-700">
       Harbor View Hills and the neighborhoods along the Back Bay offer a different setting—flatter lots with proximity to the Upper Newport Bay Ecological Reserve. Here, the design opportunity is creating gardens that complement the natural surroundings with native and habitat-supporting plantings. The Balboa Peninsula and Lido Isle present the most constrained spaces, where creative hardscape and container gardens turn compact outdoor areas into functional retreats. Steve Lytle designs for all of Newport Beach, matching the garden to the setting.
@@ -66,6 +66,80 @@ description: Landscape design and garden consultation in Newport Beach, CA. Serv
   </div>
 </section>
 
+{# Selected Work — portfolio examples, not necessarily all Newport Beach #}
+{# TODO Steve: when you have Newport Beach–specific projects, swap any of these
+   in. Until then, these read as representative work from Steve's coastal OC
+   portfolio — no explicit Newport Beach attribution. #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4">
+    <h2 class="text-4xl font-bold text-center text-forest mb-4">Selected Work</h2>
+    <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">Representative projects from Steve's portfolio. The same design approach carries through every job along the Newport coast.</p>
+    <div class="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
+      <article class="bg-white rounded-lg shadow overflow-hidden hover:shadow-lg transition-shadow">
+        <img src="/assets/images/poolgarden12.webp" alt="Mediterranean garden with tiered fountain, vibrant perennials, and pergola seating area" class="w-full h-56 object-cover bg-gray-100" loading="lazy">
+        <div class="p-6">
+          <span class="inline-block bg-spring/30 text-forest text-xs font-semibold px-2 py-1 rounded mb-3">Mediterranean</span>
+          <h3 class="text-xl font-bold mb-2">Garden with Tiered Fountain</h3>
+          <p class="text-gray-700 text-sm mb-4">A sun-drenched garden built around a tiered stone fountain. Drought-tolerant perennials, agaves, and ornamental grasses thrive in the coastal climate.</p>
+          <div class="flex flex-wrap gap-2">
+            <span class="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded">Plant Selection</span>
+            <span class="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded">Water Features</span>
+            <span class="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded">Garden Design</span>
+          </div>
+        </div>
+      </article>
+      <article class="bg-white rounded-lg shadow overflow-hidden hover:shadow-lg transition-shadow">
+        <img src="/assets/images/outdoor-fireplace-seating.webp" alt="Evening courtyard with stacked-stone fireplace, pergola lighting, and wicker seating" class="w-full h-56 object-cover bg-gray-100" loading="lazy">
+        <div class="p-6">
+          <span class="inline-block bg-spring/30 text-forest text-xs font-semibold px-2 py-1 rounded mb-3">Outdoor Living</span>
+          <h3 class="text-xl font-bold mb-2">Stone Fireplace Courtyard</h3>
+          <p class="text-gray-700 text-sm mb-4">A compact backyard turned outdoor living room. Custom stacked-stone fireplace, pergola with integrated lighting, and comfortable seating extend the home year-round.</p>
+          <div class="flex flex-wrap gap-2">
+            <span class="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded">Hardscaping</span>
+            <span class="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded">Landscape Lighting</span>
+            <span class="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded">Outdoor Living</span>
+          </div>
+        </div>
+      </article>
+      <article class="bg-white rounded-lg shadow overflow-hidden hover:shadow-lg transition-shadow">
+        <img src="/assets/images/project3.jpg" alt="Naturalistic garden with flagstone paths and river-rock dry creek bed below a hillside backdrop" class="w-full h-56 object-cover bg-gray-100" loading="lazy">
+        <div class="p-6">
+          <span class="inline-block bg-spring/30 text-forest text-xs font-semibold px-2 py-1 rounded mb-3">Hillside</span>
+          <h3 class="text-xl font-bold mb-2">Naturalistic Hillside Garden</h3>
+          <p class="text-gray-700 text-sm mb-4">A larger hillside lot designed with river-rock dry creek beds, drought-tolerant plantings, and flagstone walkways that handle drainage while feeling effortless and natural.</p>
+          <div class="flex flex-wrap gap-2">
+            <span class="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded">Drainage</span>
+            <span class="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded">Native Plantings</span>
+            <span class="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded">Hardscaping</span>
+          </div>
+        </div>
+      </article>
+    </div>
+  </div>
+</section>
+
+{# Steve's design philosophy for Newport Beach #}
+{# TODO Steve: tweak these to your actual voice if they don't sound like you.
+   These are framed as your design principles, not invented client quotes. #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 max-w-5xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-4">How Steve Designs for Newport Beach</h2>
+    <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">A garden along the coast has to do more than look good on day one. These are the principles Steve brings to every Newport Beach project.</p>
+    <div class="grid md:grid-cols-2 gap-8">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-water"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Designed for the salt and the slope</h3>
+        <p class="text-gray-700">Coastal lots face conditions that inland gardens never deal with — salt spray, onshore wind, and slope drainage. Plant palettes and hardscape decisions start from those realities, not the other way around.</p>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Better every season</h3>
+        <p class="text-gray-700">A Newport Beach garden should grow into itself over years, not need replacing every spring. Steve designs for plants that establish, mature, and look better the longer you live with them.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
 {# FAQ Section #}
 <section class="py-16 bg-white">
   <div class="container mx-auto px-4 max-w-3xl">
@@ -81,7 +155,7 @@ description: Landscape design and garden consultation in Newport Beach, CA. Serv
       </div>
       <div>
         <h3 class="text-xl font-bold text-forest mb-2">How do I landscape a hillside property in Corona del Mar?</h3>
-        <p class="text-gray-700">Hillside properties need erosion control, proper drainage, and deep-rooted plantings that stabilize slopes. We use a combination of retaining walls, terraced planting beds, and groundcovers like trailing rosemary and native dudleya that hold soil while providing coastal character. Drainage design is critical to prevent runoff from damaging the slope or neighboring properties.</p>
+        <p class="text-gray-700">Hillside properties need erosion control, proper drainage, and deep-rooted plantings that stabilize slopes. We use a combination of <a href="/hardscaping/" class="text-forest underline hover:text-lime">retaining walls</a>, terraced planting beds, and groundcovers like trailing rosemary and native dudleya that hold soil while providing coastal character. <a href="/irrigation-systems/" class="text-forest underline hover:text-lime">Drainage design</a> is critical to prevent runoff from damaging the slope or neighboring properties.</p>
       </div>
       <div>
         <h3 class="text-xl font-bold text-forest mb-2">What does a landscape consultation in Newport Beach cost?</h3>


### PR DESCRIPTION
## Summary
Acts on two of the five GA4 follow-ups surfaced in this week's 90-day audit. Both are independent, vertical slices — either could ship on its own.

### Slice 1 — Contact form trim (highest leverage)
- Required fields cut from **9 → 2** (`name`, `message`).
- Phone and email are both optional individually; a new Stimulus controller (`contact_form_controller.js`) blocks submit if **both** are empty and surfaces an inline error.
- Address / city / zip / service / referral_source moved into a collapsed `<details>` block — available but no longer a wall.
- **Why now:** GA4 showed 87 `form_start` → 14 `form_submit` over 90 days (16%). The 73 abandoners were running into the field count. This is the cheapest lift on the funnel.

### Slice 2 — Newport Beach Selected Work
- New "Selected Work" section with 3 portfolio photos (`poolgarden12.webp`, `outdoor-fireplace-seating.webp`, `project3.jpg`) styled with descriptor badges (Mediterranean / Outdoor Living / Hillside) — no false location attribution.
- Replaced an earlier draft of invented client testimonials with **"How Steve Designs for Newport Beach"** — Steve's design principles, no fake quotes.
- Cross-links to `/hardscaping/`, `/landscape-lighting/`, `/irrigation-systems/` added inline in the intro and FAQ where those services were already mentioned.
- **Why now:** Newport Beach is the highest-dwell service area in GA4 (66 views @ 19.4s avg). If this pattern moves leads, Tustin (11.6s) is next.

## Test plan
- [ ] `npm run dev` and visit `/#contact`. Submit with only name + email + message — should redirect to `/thank-you/`.
- [ ] Submit with only name + phone + message — should also succeed.
- [ ] Submit with name + message but neither phone nor email — JS validator blocks, inline error visible.
- [ ] Resize to 375px wide and re-test the above. No horizontal scroll. Touch targets usable.
- [ ] Visit `/service-areas/newport-beach/`. Scroll to Selected Work — three project cards with real images. Confirm style badges (Mediterranean / Outdoor Living / Hillside), not neighborhoods.
- [ ] Scroll further — "How Steve Designs for Newport Beach" principles render, no blockquotes.
- [ ] Inline links to `/hardscaping/`, `/landscape-lighting/`, `/irrigation-systems/` in the intro paragraph and hillside-properties FAQ entry all resolve.

## Honesty notes
- Project images are real Lytle portfolio shots but **not necessarily Newport Beach jobs**. Section heading and badges are deliberately style-based, not location-based, to avoid false attribution. Steve should swap in real Newport Beach projects when he has them.
- The design principles copy is written in a best-guess of Steve's voice. Worth a quick rewrite-pass when convenient.

## Out of scope (next sessions)
- Mobile discovery audit + UTM/GBP wiring (GA4 follow-ups #3 + #4) — checklist for Tommy to execute externally, no code work.
- Pre-existing invented testimonials on `hardscaping.njk`, `landscape-lighting.njk`, `irrigation-systems.njk` — same honesty issue, separate cleanup PR.
- Replicating the Newport Beach pattern across the other 10 service-area pages — earn the pattern here first.

## Agent notes
Each commit on this branch has a structured YAML note attached via `refs/notes/agent`. Run `~/.claude/bin/agent-review master..HEAD` to get the per-slice walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)