### PR TITLE
Replace placeholder testimonials with design principles on 6 service pages

### DIFF
--- a/src/garden-consultation.njk
+++ b/src/garden-consultation.njk
@@ -65,23 +65,22 @@ description: Transform your outdoor space with personalized guidance from one of
   </div>
 </section>
 
-{# Client Testimonials #}
+{# Steve's design principles for consultation #}
 <section class="py-16 bg-white">
-  <div class="container mx-auto px-4 text-center">
-    <h2 class="text-4xl font-bold text-forest mb-12">What Our Clients Say</h2>
-    <div class="grid md:grid-cols-3 gap-8">
-      <blockquote class="bg-gray-100 p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"Steve's consultation helped us create a stunning, low-maintenance yard. We couldn't be happier!"</p>
-        <footer class="text-sm text-gray-600">- Sarah Wilson, Costa Mesa</footer>
-      </blockquote>
-      <blockquote class="bg-gray-100 p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"Thanks to Steve's guidance, our outdoor space is now a haven of beauty and tranquility."</p>
-        <footer class="text-sm text-gray-600">- Paul Carter, Irvine</footer>
-      </blockquote>
-      <blockquote class="bg-gray-100 p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"Steve's expertise with plants and lighting turned our backyard into a nighttime paradise."</p>
-        <footer class="text-sm text-gray-600">- Megan Lee, Laguna Beach</footer>
-      </blockquote>
+  <div class="container mx-auto px-4 max-w-5xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-4">What to Expect from a Consultation</h2>
+    <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">A consultation should leave you with clarity, not more questions. These are the principles Steve brings to every property visit.</p>
+    <div class="grid md:grid-cols-2 gap-8">
+      <div class="bg-gray-50 p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-comments"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Listen first, design second</h3>
+        <p class="text-gray-700">Every property has a story and every owner has goals. The consultation starts with understanding both — how you actually use the space, what's worked, what hasn't, and what you want the garden to do for you.</p>
+      </div>
+      <div class="bg-gray-50 p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-balance-scale"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Honest about trade-offs</h3>
+        <p class="text-gray-700">Some plants won't work in your soil. Some hardscape doesn't fit the lot. Some ideas will cost more than they return. Steve tells you what won't work as clearly as what will, so you're making informed decisions, not guessing.</p>
+      </div>
     </div>
   </div>
 </section>

--- a/src/hardscaping.njk
+++ b/src/hardscaping.njk
@@ -65,23 +65,22 @@ description: Enhance your outdoor space with custom hardscaping solutions. From 
   </div>
 </section>
 
-{# Client Testimonials #}
+{# Steve's design principles for hardscaping #}
 <section class="py-16 bg-white">
-  <div class="container mx-auto px-4 text-center">
-    <h2 class="text-4xl font-bold text-forest mb-12">What Our Clients Say</h2>
-    <div class="grid md:grid-cols-3 gap-8">
-      <blockquote class="bg-gray-100 p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"The patio Steve designed for us is stunning. It's become our favorite spot!"</p>
-        <footer class="text-sm text-gray-600">- Lisa M., Laguna Beach</footer>
-      </blockquote>
-      <blockquote class="bg-gray-100 p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"Our new walkway blends perfectly with our garden. Highly recommend Lytle Landscape!"</p>
-        <footer class="text-sm text-gray-600">- Mark R., Newport Beach</footer>
-      </blockquote>
-      <blockquote class="bg-gray-100 p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"Steve and his team exceeded our expectations. Beautiful work!"</p>
-        <footer class="text-sm text-gray-600">- Sarah J., Irvine</footer>
-      </blockquote>
+  <div class="container mx-auto px-4 max-w-5xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-4">Steve's Approach to Hardscaping</h2>
+    <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">Good hardscape outlives the people who installed it. These are the principles Steve brings to every project.</p>
+    <div class="grid md:grid-cols-2 gap-8">
+      <div class="bg-gray-50 p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-hammer"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Built to last in Orange County weather</h3>
+        <p class="text-gray-700">Quality materials, proper base preparation, and drainage that handles the swing from dry summers to heavy winter rain. Patios and walls that look as good in ten years as they do on day one.</p>
+      </div>
+      <div class="bg-gray-50 p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-ruler-combined"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Designed before it's installed</h3>
+        <p class="text-gray-700">Slope, drainage, and material decisions get worked out on paper before anyone breaks ground. It's the difference between a feature that solves problems and one that creates them.</p>
+      </div>
     </div>
   </div>
 </section>

--- a/src/irrigation-systems.njk
+++ b/src/irrigation-systems.njk
@@ -60,23 +60,22 @@ description: Save water, reduce costs, and ensure your plants thrive with smart 
   </div>
 </section>
 
-{# Client Testimonials #}
+{# Steve's design principles for irrigation #}
 <section class="py-16 bg-white">
-  <div class="container mx-auto px-4 text-center">
-    <h2 class="text-4xl font-bold text-forest mb-12">What Our Clients Say</h2>
-    <div class="grid md:grid-cols-3 gap-8">
-      <blockquote class="bg-gray-100 p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"The irrigation system Steve installed has drastically reduced our water bill while keeping our garden lush and vibrant!"</p>
-        <footer class="text-sm text-gray-600">- Amanda Green, Newport Beach</footer>
-      </blockquote>
-      <blockquote class="bg-gray-100 p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"Lytle Landscape's expertise in water conservation is unmatched. Highly recommend their services!"</p>
-        <footer class="text-sm text-gray-600">- Michael Brown, Laguna Hills</footer>
-      </blockquote>
-      <blockquote class="bg-gray-100 p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"Our smart irrigation system is a game-changer. The automation saves us time and effort!"</p>
-        <footer class="text-sm text-gray-600">- Sarah Lee, Irvine</footer>
-      </blockquote>
+  <div class="container mx-auto px-4 max-w-5xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-4">Steve's Approach to Irrigation</h2>
+    <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">Most water in Southern California gardens ends up on hardscape or down storm drains. These are the principles that keep it on the plants instead.</p>
+    <div class="grid md:grid-cols-2 gap-8">
+      <div class="bg-gray-50 p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-tint"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Water where it counts</h3>
+        <p class="text-gray-700">Zoned by hydrozone — shade beds get less than full-sun lawns, drip for shrubs, rotors for turf. No overspray onto patios and sidewalks. Every gallon goes where a plant can use it.</p>
+      </div>
+      <div class="bg-gray-50 p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-microchip"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Smart from the start</h3>
+        <p class="text-gray-700">Weather-based controllers and flow sensors built in, not bolted on later. The system adjusts when the season does, and tells you when a line breaks instead of running for hours unnoticed.</p>
+      </div>
     </div>
   </div>
 </section>

--- a/src/landscape-lighting.njk
+++ b/src/landscape-lighting.njk
@@ -60,23 +60,22 @@ description: Transform your garden into a nighttime paradise with custom landsca
   </div>
 </section>
 
-{# Client Testimonials #}
+{# Steve's design principles for landscape lighting #}
 <section class="py-16 bg-white">
-  <div class="container mx-auto px-4 text-center">
-    <h2 class="text-4xl font-bold text-forest mb-12">What Our Clients Say</h2>
-    <div class="grid md:grid-cols-3 gap-8">
-      <blockquote class="bg-gray-100 p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"Steve's lighting transformed our garden into a magical nighttime retreat!"</p>
-        <footer class="text-sm text-gray-600">- Jessica Carter, Newport Beach</footer>
-      </blockquote>
-      <blockquote class="bg-gray-100 p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"We feel so much safer with the pathway lighting Steve installed. Thank you!"</p>
-        <footer class="text-sm text-gray-600">- Michael Davis, Irvine</footer>
-      </blockquote>
-      <blockquote class="bg-gray-100 p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"Our garden is now the highlight of our home, day and night."</p>
-        <footer class="text-sm text-gray-600">- Sarah Collins, Laguna Beach</footer>
-      </blockquote>
+  <div class="container mx-auto px-4 max-w-5xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-4">Steve's Approach to Landscape Lighting</h2>
+    <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">Outdoor lighting either reveals a garden at night or floods it. These are the principles that put a project in the first category.</p>
+    <div class="grid md:grid-cols-2 gap-8">
+      <div class="bg-gray-50 p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-lightbulb"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Light to reveal, not to flood</h3>
+        <p class="text-gray-700">Restraint matters more than brightness. Subtle accent lighting on architecture, specimen trees, and pathways outperforms washing the whole yard — and lets people actually see the stars overhead.</p>
+      </div>
+      <div class="bg-gray-50 p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-shield-alt"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Built for the long term</h3>
+        <p class="text-gray-700">Low-voltage LED, marine-grade fixtures in coastal locations, and wiring planned for additions years down the line. A lighting system shouldn't need to be redone every time the garden changes.</p>
+      </div>
     </div>
   </div>
 </section>

--- a/src/plant-selection.njk
+++ b/src/plant-selection.njk
@@ -65,23 +65,22 @@ description: Expert plant selection and garden design for Orange County homes. C
   </div>
 </section>
 
-{# Client Testimonials #}
+{# Steve's design principles for plant selection #}
 <section class="py-16 bg-white">
-  <div class="container mx-auto px-4 text-center">
-    <h2 class="text-4xl font-bold text-forest mb-12">What Our Clients Say</h2>
-    <div class="grid md:grid-cols-3 gap-8">
-      <blockquote class="bg-gray-100 p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"Steve's plant knowledge is unparalleled. My garden is now the talk of the neighborhood!"</p>
-        <footer class="text-sm text-gray-600">- Eve R., Irvine</footer>
-      </blockquote>
-      <blockquote class="bg-gray-100 p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"Thanks to Lytle Landscape, my yard is a sustainable haven for native wildlife."</p>
-        <footer class="text-sm text-gray-600">- Johnny Mills, Laguna Beach</footer>
-      </blockquote>
-      <blockquote class="bg-gray-100 p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"Steve turned my overgrown yard into a beautiful, low-maintenance retreat."</p>
-        <footer class="text-sm text-gray-600">- Emily Johnson, Dana Point</footer>
-      </blockquote>
+  <div class="container mx-auto px-4 max-w-5xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-4">Steve's Approach to Plant Selection</h2>
+    <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">The right plant in the wrong place dies. The wrong plant in the right place is just maintenance you didn't sign up for. These are the principles that put plants where they want to be.</p>
+    <div class="grid md:grid-cols-2 gap-8">
+      <div class="bg-gray-50 p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-leaf"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Right plant, right place</h3>
+        <p class="text-gray-700">Sun, soil, slope, and water all dictate what thrives where. Steve matches plants to the conditions of your specific property — not what's trending in the catalog or what looked good at someone else's house.</p>
+      </div>
+      <div class="bg-gray-50 p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-sun"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Climate-adapted from the start</h3>
+        <p class="text-gray-700">Drought-tolerant Mediterranean, California native, and locally-appropriate species that look better with less water, not more. A garden built around the climate ages well; one fighting it gets harder every year.</p>
+      </div>
     </div>
   </div>
 </section>

--- a/src/vegetable-gardens.njk
+++ b/src/vegetable-gardens.njk
@@ -90,23 +90,22 @@ description: Custom raised bed and vegetable garden design in Orange County. Ced
   </div>
 </section>
 
-{# Client Testimonials #}
+{# Steve's design principles for vegetable gardens #}
 <section class="py-16 bg-gray-50">
-  <div class="container mx-auto px-4 text-center">
-    <h2 class="text-4xl font-bold text-forest mb-12">What Our Clients Say</h2>
-    <div class="grid md:grid-cols-3 gap-8">
-      <blockquote class="bg-white p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"Steve built us four beautiful raised beds and now we grow tomatoes, peppers, and herbs year-round. The kids love picking vegetables right from the backyard."</p>
-        <footer class="text-sm text-gray-600">- Jennifer Torres, Tustin</footer>
-      </blockquote>
-      <blockquote class="bg-white p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"The veggie boxes fit perfectly with our existing landscape. Steve's soil mix was amazing—everything we planted took off immediately."</p>
-        <footer class="text-sm text-gray-600">- David Chen, Orange</footer>
-      </blockquote>
-      <blockquote class="bg-white p-6 rounded-lg shadow">
-        <p class="text-gray-700 mb-4">"We wanted a vegetable garden but didn't want it to look out of place. Steve designed beds that look like they've always been part of the yard."</p>
-        <footer class="text-sm text-gray-600">- Karen Mitchell, Villa Park</footer>
-      </blockquote>
+  <div class="container mx-auto px-4 max-w-5xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-4">Steve's Approach to Vegetable Gardens</h2>
+    <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">A productive vegetable garden is mostly about what happens before the first seed goes in. These are the principles that keep beds producing season after season.</p>
+    <div class="grid md:grid-cols-2 gap-8">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Soil first, plants second</h3>
+        <p class="text-gray-700">Yield comes from the soil. Steve builds the right mix for the crops you want to grow, then picks the varieties — not the other way around. Skip the soil work and you'll be fighting it every season.</p>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-sync-alt"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Designed to keep producing</h3>
+        <p class="text-gray-700">Raised beds sized for crop rotation, irrigation built in from day one, and layouts that make harvest and replanting easy. The garden should reward you for tending it, not punish you.</p>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
Six service pages each shipped with three placeholder client testimonials (18 in total, attributed to invented names like Lisa M./Laguna Beach, Mark R./Newport Beach, etc.). Pre-existing tech debt from the original site build.

Each testimonial block is replaced with a **"Steve's Approach to <Service>"** section: two design principles attributed to Steve himself. Same shape and styling as the principles section in #8.

| Page | Principles |
|---|---|
| `hardscaping.njk` | Built to last in Orange County weather / Designed before it's installed |
| `landscape-lighting.njk` | Light to reveal, not to flood / Built for the long term |
| `irrigation-systems.njk` | Water where it counts / Smart from the start |
| `vegetable-gardens.njk` | Soil first, plants second / Designed to keep producing |
| `plant-selection.njk` | Right plant, right place / Climate-adapted from the start |
| `garden-consultation.njk` | Listen first, design second / Honest about trade-offs |

Real testimonials can be added later — either replacing the principles block or alongside it — once Steve provides actual client quotes.

## Test plan
- [ ] `npm run dev`, then visit each page in turn:
  - `/hardscaping/`, `/landscape-lighting/`, `/irrigation-systems/`, `/vegetable-gardens/`, `/plant-selection/`, `/garden-consultation/`
- [ ] On each page, scroll past the existing services/process content to the new "Steve's Approach to ..." section. Verify two principle cards render, no blockquotes, no fake names.
- [ ] Background color of the new section should match the previous testimonials section bg (white on 5 pages, gray-50 on vegetable-gardens) — visual alternation preserved.
- [ ] Skim each principle's copy and rewrite anything that doesn't sound like Steve's voice. **Voice approximation is the weakest part of this PR** — best-guess Steve, not actual Steve.

## Honesty notes
- Principles copy is in best-guess Steve voice. Worth a rewrite pass when convenient.
- **NOT touched:** the homepage testimonials in `index.njk` and the Testimonials Modal. Those are real client quotes — leaving them alone.
- `service-areas/newport-beach.njk` is in PR #8, not this one — to avoid merge conflicts. Its placeholder testimonial cleanup ships in that PR.

## Relationship to #8
This is a separate PR off `master` because it's a different concern (placeholder cleanup across service pages) from the GA4 follow-ups in #8 (form trim + Newport Beach Selected Work). Either PR can merge first without affecting the other.

## Agent notes
This commit has a structured YAML note attached via `refs/notes/agent`. Run `~/.claude/bin/agent-review master..HEAD` from this branch for the structured walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
