### PR TITLE
Add Working with Steve concierge section to homepage

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -26,10 +26,10 @@ description: Expert landscape design and garden consultation in Orange County by
     <div class="max-w-3xl mx-auto text-center mb-16">
       <h2 class="text-4xl font-bold text-forest mb-6">Creating Orange County's Finest Landscapes Since 1982</h2>
       <p class="text-lg text-gray-700 mb-2">
-        Lytle Landscape & Construction stands as one of Orange County's premier landscape design and construction companies. For over four decades, we've transformed ordinary outdoor spaces into extraordinary garden sanctuaries.
+        Lytle Landscape & Construction has served Orange County homeowners for over four decades. We take on a small number of projects each year so each gets the attention it deserves.
       </p>
       <p class="text-lg text-gray-700">
-        Licensed and insured (Lic #{{ site.license }}), Lytle Landscape & Construction is dedicated to transforming outdoor spaces into functional, beautiful environments that reflect your unique lifestyle. Whether it's plant selection, hardscape design, or outdoor lighting, we approach every project with a commitment to excellence.
+        Licensed and insured (Lic #{{ site.license }}), Lytle Landscape & Construction is a concierge landscape service. Steve walks every project from first consultation through final install. Plant selection, hardscape, lighting, irrigation: every job gets his full attention.
       </p>
     </div>
 
@@ -149,6 +149,42 @@ description: Expert landscape design and garden consultation in Orange County by
             {{ site.phone }}
           </a>
         </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# Working with Steve — concierge positioning #}
+{# TODO Steve: rewrite the section intro and card copy in your voice if any of it
+   doesn't sound like you. The four cards capture the model; the words are placeholder. #}
+<section id="working-with-steve" class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 max-w-5xl">
+    <div class="text-center mb-16">
+      <h2 class="text-4xl font-bold text-forest mb-4">Working with Steve</h2>
+      <p class="text-lg text-gray-700 max-w-2xl mx-auto">
+        Lytle Landscape is a concierge service. Steve takes a small number of projects at a time so each one gets his full attention, from the first walk-through to the last plant in the ground.
+      </p>
+    </div>
+    <div class="grid md:grid-cols-2 gap-8">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-phone-alt"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Steve answers the phone</h3>
+        <p class="text-gray-700">When you call Lytle Landscape, you talk to Steve, not a call center. The person designing your project is the person you reach.</p>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-bullseye"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">One project at a time</h3>
+        <p class="text-gray-700">Steve takes on a small number of projects so each gets his full attention. You won't be juggled against a queue of other jobs.</p>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-pencil-ruler"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Hands on from sketch to soil</h3>
+        <p class="text-gray-700">Steve walks every job from the first consultation through plant placement on install day. Nothing gets handed off to someone who hasn't seen the property.</p>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Follow-up after install</h3>
+        <p class="text-gray-700">A garden isn't done the day it's planted. Steve checks in after install to see how things are establishing and adjusts what needs adjusting.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Steve's positioning is concierge landscape design: one project at a time, hands-on from sketch to soil, follow-up after install. The existing About section gestured at this ("personal consultation with Steve") but never named the model. This PR adds a dedicated section between About and Services that names the concierge spine and walks through what it actually looks like.

This is **slice 1 of 3** in a small epic that builds out the spine + two downstream pages that inherit from it:

1. **This PR** — Concierge positioning on the homepage
2. **Next** — `/after-tree-removal/` referral landing page (for the tree-service partner that sends torn-up-yard homeowners)
3. **After that** — `/partners/` page (footer link only) for B2B outreach to designers, arborists, etc.

## What changed

- **New section: "Working with Steve"** — inserted between About and Services. Names the concierge model in the intro paragraph; 4 cards walk through the experience:
  - Steve answers the phone
  - One project at a time
  - Hands on from sketch to soil
  - Follow-up after install
- **About prose refresh** — generic "premier landscape design and construction" replaced with concierge-leaning copy. Names the model once in the second paragraph.

## Test plan

- [ ] `npm run dev`, visit `/`. Confirm new section sits between About and Services.
- [ ] Confirm card grid is 2x2 on desktop, single column on mobile (375px viewport). No horizontal scroll.
- [ ] Walk the page top to bottom — does it read as one coherent story? (who Steve is → how he works → what he does → proof → contact)
- [ ] Read the card copy and the rewritten About paragraphs. **Rewrite anything that doesn't sound like Steve.** TODO marker is in the source for the section intro and card bodies.

## Body plan notes for reviewer

- New section refuses to know about services or pricing. Services are next; pricing happens in the consultation. This section is about the experience of working with Steve and nothing else.
- Section bg-color (`bg-gray-50`) bridges About's white-ending gradient and Services' white-starting gradient — a subtle ribbon, not a hard break.
- No CTA inside the section. About above has Schedule Consultation; Services below is itself a CTA grid. Adding a third would compete.

## Deviation from plan

Plan called for "two-three small edits" to the About prose. I rewrote both paragraphs more substantively because the original copy was generic boilerplate that actively fought the new concierge framing. Surfaced as a deviation in the agent note. About prose is in scope; the depth of the rewrite was heavier than originally scoped.

## Honesty notes

- The section intro paragraph and the 4 card bodies are best-guess Steve voice. Steve should rewrite anything that doesn't sound like him.
- TODO marker comment is in the source. Nunjucks strips it from served HTML, so visitors don't see "TODO Steve" anywhere on the live page.

## Relationship to other open PRs

This is independent of PR #8 (form trim + Newport Beach Selected Work) and PR #9 (placeholder testimonials → principles on 6 service pages). Any merge order works.

## Agent notes

This commit has a structured YAML note attached via `refs/notes/agent`. Run `~/.claude/bin/agent-review master..HEAD` from this branch for the structured walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
