### PR TITLE
Add /after-tree-removal/ referral landing page

### DIFF
--- a/src/after-tree-removal.njk
+++ b/src/after-tree-removal.njk
@@ -1,0 +1,118 @@
+---
+layout: layouts/base.njk
+title: After Tree Removal, Yard Restoration
+description: Tree removal leaves cut irrigation lines, crushed lawn, and a root cavity. Steve Lytle restores the whole yard, irrigation, lawn, soil, and replanting, as one project rather than five.
+---
+
+{# TODO Steve: rewrite copy in your voice where it doesn't sound like you.
+   The page is the structure; the words are placeholder. #}
+
+{# Hero #}
+<section class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 max-w-3xl text-center">
+    <h1 class="text-5xl font-bold text-forest mb-6">Lost a tree? Here's what comes next.</h1>
+    <p class="text-lg text-gray-700 mb-8">
+      Tree removal is rough on a yard. Irrigation lines get cut, lawn gets crushed, and a large root cavity gets left behind. Steve Lytle restores the whole picture as one project: irrigation, lawn, soil, and replanting, handled by one person who walks the entire job.
+    </p>
+    <a href="/#contact" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg text-lg font-semibold hover:bg-spring transition-colors">
+      Schedule a Consultation
+    </a>
+  </div>
+</section>
+
+{# What tree removal actually breaks #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-5xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-4">What tree removal actually breaks</h2>
+    <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">
+      A tree removal crew is paid to take down the tree, not to put the yard back together. Here's what's usually left behind.
+    </p>
+    <div class="grid md:grid-cols-2 gap-8">
+      <div class="bg-gray-50 p-6 rounded-lg">
+        <div class="text-3xl text-lime mb-3"><i class="fas fa-faucet"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-2">Cut irrigation lines</h3>
+        <p class="text-gray-700">Drip lines and lateral pipes run right through where roots used to live. Removal almost always severs them. Some leaks show up immediately; others wait for the next time the system runs.</p>
+      </div>
+      <div class="bg-gray-50 p-6 rounded-lg">
+        <div class="text-3xl text-lime mb-3"><i class="fas fa-leaf"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-2">Crushed lawn and beds</h3>
+        <p class="text-gray-700">Heavy equipment compacts the soil and tears up turf. Plants near the work zone get trampled, and what survives sits in compacted ground that no longer drains the way it did.</p>
+      </div>
+      <div class="bg-gray-50 p-6 rounded-lg">
+        <div class="text-3xl text-lime mb-3"><i class="fas fa-mountain"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-2">A root cavity to fill</h3>
+        <p class="text-gray-700">Stump grinding leaves a wide depression of chips and disturbed soil. Filling it correctly takes the right soil mix and time to settle, or whatever you plant there sinks and struggles.</p>
+      </div>
+      <div class="bg-gray-50 p-6 rounded-lg">
+        <div class="text-3xl text-lime mb-3"><i class="fas fa-sun"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-2">Sudden sun exposure</h3>
+        <p class="text-gray-700">Plants that lived in the tree's shade for years are now in full sun. Some will burn. Some will need more water than the irrigation was designed to deliver. The whole planting plan around the old tree needs a second look.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# What Steve restores #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 max-w-5xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-4">What Steve restores</h2>
+    <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">
+      Steve handles the whole restoration personally. One walk-through, one plan, one person on every step.
+    </p>
+    <div class="grid md:grid-cols-2 gap-8">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-tint"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Irrigation diagnosis and repair</h3>
+        <p class="text-gray-700 mb-3">Steve finds the cut lines, repairs them, and rezones the system to match what's actually planted now, not what was planted ten years ago. Smart controllers and flow sensors built in where they make sense.</p>
+        <a href="/irrigation-systems/" class="text-forest font-semibold hover:text-lime transition-colors">More on irrigation &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Lawn restoration</h3>
+        <p class="text-gray-700">Compacted soil gets aerated and amended. Damaged turf gets replaced or reseeded with grass varieties matched to the new sun and water conditions. The lawn comes back established, not patched.</p>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-hand-holding-water"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Soil amendment in the cavity</h3>
+        <p class="text-gray-700">The root cavity gets filled with the right blend for what's going to grow there. Steve picks the mix based on whether the area is going back to lawn, beds, or a new specimen tree, and lets it settle properly before planting.</p>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-tree"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Replanting for the new conditions</h3>
+        <p class="text-gray-700 mb-3">The plants that thrived under the old tree may not thrive in full sun. Steve rebuilds the planting plan around what works now, with species matched to the new light, water, and soil.</p>
+        <a href="/plant-selection/" class="text-forest font-semibold hover:text-lime transition-colors">More on plant selection &rarr;</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# Concierge spine #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-3xl text-center">
+    <h2 class="text-4xl font-bold text-forest mb-6">One project, one person, one yard</h2>
+    <p class="text-lg text-gray-700 mb-4">
+      The alternative is hiring an irrigation contractor, a lawn company, a soil supplier, and a designer separately, and hoping they don't blame each other when something goes wrong.
+    </p>
+    <p class="text-lg text-gray-700">
+      Steve walks the whole job. One person looks at your yard as one yard, not five disconnected slices. You get one point of contact, one timeline, and one person responsible for the result.
+    </p>
+  </div>
+</section>
+
+{# CTA #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h2 class="text-4xl font-bold text-forest mb-6">Ready to put your yard back together?</h2>
+    <p class="text-lg text-gray-700 mb-8">
+      Tell Steve a little about the tree that came out and what's left. He'll come walk the property and put a plan together.
+    </p>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a href="/#contact" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg font-semibold hover:bg-spring transition-colors">
+        Schedule Consultation
+      </a>
+      <a href="tel:{{ site.phoneRaw }}" class="inline-block border-2 border-forest text-forest px-8 py-4 rounded-lg font-semibold hover:bg-forest hover:text-white transition-colors">
+        Call {{ site.phone }}
+      </a>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary

Steve has a tree-service partner that sends torn-up-yard homeowners his way after removing large trees. Until now those referrals had nowhere specific to land — the tree service had to send people to the generic homepage. This adds a single-purpose landing page the tree service can hand homeowners directly:

**URL:** `/after-tree-removal/` (not in nav by design — discoverable only via direct link)

This is **slice 2 of 3** in the concierge epic. Slice 1 (#10) added the concierge spine on the homepage; slice 3 will add `/partners/` for B2B outreach.

## Page structure

1. **Hero** — "Lost a tree? Here's what comes next." Validates the homeowner's moment before pitching.
2. **What tree removal actually breaks** — 4 problem cards: cut irrigation lines, crushed lawn and beds, the root cavity, sudden sun exposure.
3. **What Steve restores** — 4 solution cards, each attributed explicitly to Steve's hands-on work: irrigation diagnosis + repair, lawn restoration, soil amendment in the cavity, replanting for the new conditions. Internal links to `/irrigation-systems/` and `/plant-selection/`.
4. **Concierge spine** — "One project, one person, one yard." Names the body plan: the alternative is hiring four contractors and hoping they don't blame each other.
5. **CTA** — Schedule consultation + phone.

## Test plan

- [ ] `npm run dev`, visit `/after-tree-removal/`. Page renders, all 5 sections present.
- [ ] All 4 problem cards render with icons (faucet, leaf, mountain, sun) and content.
- [ ] All 4 restoration cards render with icons (tint, seedling, hand-holding-water, tree). Internal links to `/irrigation-systems/` and `/plant-selection/` resolve.
- [ ] Concierge framing paragraph reads like Steve. Rewrite if not.
- [ ] CTA links to `/#contact` and `tel:` both work.
- [ ] Mobile viewport (375px): no horizontal scroll, cards stack, touch targets usable.

## Body plan notes for reviewer

- Page refuses to be a generic landscape sales pitch. It speaks to a specific homeowner moment.
- Restoration cards explicitly attribute hands-on work to Steve. If Steve actually subs any of this out (lawn, soil), the relevant card needs softening. Locked decision in the plan was that Steve performs all of it himself — flagging here as the load-bearing assumption.
- Not in main nav. Referral landing pages don't belong in the browse-able nav.
- No hero image yet. Steve can add a torn-up-yard or restoration-in-progress photo later. Page is text-heavy on first impression but doesn't block ship on a photo Steve may not have.

## Honesty notes

- Copy is best-guess Steve voice across all sections. TODO marker in source for Steve to rewrite.
- First pass shipped em-dashes in title and meta description. Caught them during browser verification and replaced with commas before the commit.

## Relationship to other open PRs

Independent of #8 (form trim + Newport Beach), #9 (service-page principles), and #10 (concierge spine on homepage). Any merge order works, though the page reads best when slice 1 (#10) is also live so visitors who click the CTA land on a homepage that already names the concierge model.

## Agent notes

This commit has a structured YAML note attached via `refs/notes/agent`. Run `~/.claude/bin/agent-review master..HEAD` from this branch for the structured walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
