### PR TITLE
Add /partners/ page + footer link for B2B outreach

### DIFF
--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -52,7 +52,11 @@
 
     {# Copyright #}
     <div class="border-t border-gray-600 mt-8 pt-8 text-center text-gray-400 text-sm">
-      <p>&copy; {% year %} {{ site.name }}. All rights reserved.</p>
+      <p>
+        &copy; {% year %} {{ site.name }}. All rights reserved.
+        <span class="mx-2 text-gray-600">|</span>
+        <a href="/partners/" class="text-gray-400 hover:text-spring transition-colors">For Pros</a>
+      </p>
     </div>
   </div>
 </footer>

--- a/src/partners.njk
+++ b/src/partners.njk
@@ -1,0 +1,188 @@
+---
+layout: layouts/base.njk
+title: For Pros, Refer with Confidence
+description: Lytle Landscape works with tree services, landscape designers, arborists, irrigation contractors, and real estate agents. Steve handles homeowner-facing landscape projects end to end and keeps the referring pro in the loop.
+---
+
+{# TODO Steve: rewrite copy in your voice where it doesn't sound like you.
+   The page structure is locked; the words are placeholder. #}
+
+{# Hero #}
+<section class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 max-w-3xl text-center">
+    <p class="text-spring font-semibold uppercase tracking-wide mb-4">For tree services, designers, arborists, and other pros</p>
+    <h1 class="text-5xl font-bold text-forest mb-6">Refer with confidence.</h1>
+    <p class="text-lg text-gray-700 mb-8">
+      Lytle Landscape works with other pros across Orange County. Steve takes the homeowner-facing landscape work end to end, keeps you informed, and won't step on your relationship. If you have a client who needs the landscape side handled well, this is the page to bookmark.
+    </p>
+    <a href="#partner-form" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg text-lg font-semibold hover:bg-spring transition-colors">
+      Start a Conversation
+    </a>
+  </div>
+</section>
+
+{# Who Steve is, professionally #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-3xl">
+    <h2 class="text-4xl font-bold text-forest mb-6 text-center">About Steve</h2>
+    <p class="text-lg text-gray-700 mb-8 text-center">
+      Steve Lytle has worked Orange County properties for over four decades. The credentials matter less than the references, but for the record:
+    </p>
+    <ul class="grid md:grid-cols-2 gap-4 text-gray-700 list-disc list-inside max-w-2xl mx-auto">
+      <li>California Certified Nurseryman (CCN)</li>
+      <li>Professional Horticulturist</li>
+      <li>Licensed contractor (Lic #{{ site.license }})</li>
+      <li>40+ years in Orange County</li>
+      <li>Insured</li>
+      <li>One project at a time, owner-operated</li>
+    </ul>
+  </div>
+</section>
+
+{# Who Steve wants to partner with #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 max-w-5xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-4">Who we partner with</h2>
+    <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">
+      If you work with homeowners who need a landscape professional after your part of the job is done, there's a good chance we should talk.
+    </p>
+    <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+      <div class="bg-white p-6 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-3"><i class="fas fa-tree"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-2">Tree services</h3>
+        <p class="text-gray-700">After a large removal, your client's irrigation, lawn, and planting plan need someone who looks at the whole yard. Hand them off and you're done.</p>
+      </div>
+      <div class="bg-white p-6 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-3"><i class="fas fa-pencil-ruler"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-2">Landscape designers</h3>
+        <p class="text-gray-700">Steve installs the design, sources the right plants, and brings the drawing to life on the ground. You stay in the loop without managing the build.</p>
+      </div>
+      <div class="bg-white p-6 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-3"><i class="fas fa-leaf"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-2">Arborists</h3>
+        <p class="text-gray-700">When a tree assessment turns into a planting recommendation or a soil intervention, Steve handles the horticultural follow-through.</p>
+      </div>
+      <div class="bg-white p-6 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-3"><i class="fas fa-faucet"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-2">Irrigation contractors</h3>
+        <p class="text-gray-700">If your work stops at the system and your client needs design, planting, or soil work, Steve picks it up from there.</p>
+      </div>
+      <div class="bg-white p-6 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-3"><i class="fas fa-home"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-2">Real estate agents</h3>
+        <p class="text-gray-700">Listings often need the yard pulled together before showings. Steve can handle a fast refresh or a longer rebuild, on a timeline that respects the close date.</p>
+      </div>
+      <div class="bg-white p-6 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-3"><i class="fas fa-handshake"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-2">Other pros</h3>
+        <p class="text-gray-700">If your work and Steve's overlap and you have a client who needs the landscape side handled well, get in touch. We'll figure out if there's a fit.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# How partnership works #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-5xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">How partnership works</h2>
+    <div class="grid md:grid-cols-2 gap-8">
+      <div class="bg-gray-50 p-8 rounded-lg">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-user-tie"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Steve takes the homeowner-facing role</h3>
+        <p class="text-gray-700">Once you hand off, Steve handles the consultation, the design conversations, and the install. You don't have to manage the build or babysit the relationship.</p>
+      </div>
+      <div class="bg-gray-50 p-8 rounded-lg">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-route"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">One project, end to end</h3>
+        <p class="text-gray-700">Steve walks the whole job himself, from first walk-through through final plant placement. Your client gets one point of contact for the landscape side, not five.</p>
+      </div>
+      <div class="bg-gray-50 p-8 rounded-lg">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-comments"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">You stay informed</h3>
+        <p class="text-gray-700">Steve loops the referring pro in on major decisions and final outcomes. You don't have to ask how it went; you'll already know.</p>
+      </div>
+      <div class="bg-gray-50 p-8 rounded-lg">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-shield-alt"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Steve doesn't poach or undercut</h3>
+        <p class="text-gray-700">The work Steve takes is the work that was referred. If the client later needs something in your wheelhouse, Steve sends them back to you, not to a competitor.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# Partner contact form #}
+<section id="partner-form" class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 max-w-3xl">
+    <div class="bg-white rounded-xl shadow-lg p-8">
+      <div class="text-center mb-8">
+        <h2 class="text-4xl font-bold text-forest mb-4">Let's talk</h2>
+        <p class="text-gray-600">Tell Steve a little about your work and a client you might refer. He'll reach out personally.</p>
+      </div>
+
+      <form action="https://api.web3forms.com/submit" method="POST" class="space-y-6">
+        {# Hidden fields for Web3Forms. Distinct subject so Steve can filter partner inquiries. #}
+        <input type="hidden" name="access_key" value="{{ site.forms.web3formsKey }}">
+        <input type="hidden" name="subject" value="New Partner Inquiry">
+        <input type="hidden" name="from_name" value="{{ site.name }} Partner Form">
+        <input type="hidden" name="redirect" value="{{ site.url }}/thank-you/">
+
+        {# Name and Company #}
+        <div class="grid md:grid-cols-2 gap-6">
+          <div>
+            <label for="partner-name" class="block text-sm font-medium text-gray-700">Your Name *</label>
+            <input type="text" id="partner-name" name="name" required placeholder="Your name" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+          </div>
+          <div>
+            <label for="partner-company" class="block text-sm font-medium text-gray-700">Company *</label>
+            <input type="text" id="partner-company" name="company" required placeholder="Your company name" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+          </div>
+        </div>
+
+        {# Email and Phone #}
+        <div class="grid md:grid-cols-2 gap-6">
+          <div>
+            <label for="partner-email" class="block text-sm font-medium text-gray-700">Email *</label>
+            <input type="email" id="partner-email" name="email" required placeholder="you@yourcompany.com" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+          </div>
+          <div>
+            <label for="partner-phone" class="block text-sm font-medium text-gray-700">Phone</label>
+            <input type="tel" id="partner-phone" name="phone" placeholder="(123) 456-7890" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+          </div>
+        </div>
+
+        {# Type of pro #}
+        <div>
+          <label for="partner-type" class="block text-sm font-medium text-gray-700">What kind of work do you do? *</label>
+          <select id="partner-type" name="pro_type" required class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+            <option value="" disabled selected>Select one</option>
+            <option value="Tree Service">Tree service</option>
+            <option value="Landscape Designer">Landscape designer</option>
+            <option value="Arborist">Arborist</option>
+            <option value="Irrigation Contractor">Irrigation contractor</option>
+            <option value="Real Estate Agent">Real estate agent</option>
+            <option value="Other">Other</option>
+          </select>
+        </div>
+
+        {# Message #}
+        <div>
+          <label for="partner-message" class="block text-sm font-medium text-gray-700">Tell Steve about your work or a client *</label>
+          <textarea id="partner-message" name="message" required rows="5" placeholder="What kind of project, what your client needs, how you'd like to partner" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest"></textarea>
+        </div>
+
+        {# hCaptcha #}
+        <div class="h-captcha" data-sitekey="50b2fe65-b00b-4b9e-ad62-3ba471098be2"></div>
+
+        {# Submit #}
+        <button type="submit" class="w-full bg-forest text-white py-3 rounded-lg hover:bg-lime transition-colors">
+          Send Inquiry
+        </button>
+      </form>
+    </div>
+
+    {# Polite redirect for homeowners who land here #}
+    <p class="text-center text-sm text-gray-500 mt-8">
+      Homeowner looking for a consultation? <a href="/#contact" class="text-forest underline hover:text-lime">Visit our contact page</a> instead.
+    </p>
+  </div>
+</section>


### PR DESCRIPTION
## Summary

Steve gets referrals from tree services, landscape designers, arborists, and other pros, but until now had no page to point them to or include in outreach. This adds `/partners/` as a B2B outreach asset, footer-linked but not in main nav.

**This is slice 3 of 3** in the original concierge epic. A new slice 4 (a `/from-your-designer/` landing page for homeowners referred by their landscape designer, parallel to `/after-tree-removal/`) will follow in a separate PR.

## What's in this PR

- `src/partners.njk` — new page at `/partners/`
- `src/_includes/partials/footer.njk` — small "For Pros" link added in the copyright row, site-wide

## Page structure

1. **Hero** — "Refer with confidence." Peer-to-peer pitch, scrolls to form.
2. **About Steve** — Credentials in list form (CCN, Pro Hort, Lic #, 40+ years).
3. **Who we partner with** — 6 pro-type cards: tree services, landscape designers, arborists, irrigation contractors, real estate agents, and an "Other pros" catch-all.
4. **How partnership works** — 4 principles: Steve takes the homeowner-facing role, one project end to end, you stay informed, no poaching or undercutting.
5. **Partner contact form** — Distinct from the homeowner form via subject differentiator (see below). B2B fields: name, company, email (all required), phone (optional), pro type select, message. hCaptcha included.
6. **Homeowner redirect** — Polite line at the bottom: "Homeowner looking for a consultation? Visit our contact page instead."

## Form design

Uses the same Web3Forms endpoint as the homeowner form (same `access_key`) but with:
- `subject: "New Partner Inquiry"` (so Steve can filter partner leads in his inbox)
- `from_name: "Lytle Landscape Partner Form"` (so the email arrival looks distinct)
- `redirect: /thank-you/` (reuses existing thank-you page)

Required: name, company, email, pro_type, message. Phone is optional. Different rule than the homeowner form's at-least-one-of-phone-or-email because email is the B2B baseline.

## Footer link

Quietly placed in the copyright row, site-wide:

```
© 2026 Lytle Landscape & Construction. All rights reserved. | For Pros
```

Verified the link appears on home, service pages, and service-area pages.

## Test plan

- [ ] `npm run dev`, visit `/partners/`. All 5 sections render in order.
- [ ] Click "Start a Conversation" — should smooth-scroll to the partner form.
- [ ] Submit the form with all required fields. Confirm redirect to `/thank-you/`.
- [ ] Check Steve's Web3Forms inbox / connected email: the submission should land with subject "New Partner Inquiry" (not "New Contact Form Submission" like homeowner submissions).
- [ ] Scroll any page on the site to the footer. "For Pros" link should appear in the copyright row.
- [ ] Mobile viewport (375px): no horizontal scroll, form usable, cards stack.
- [ ] Voice pass: skim hero, "How partnership works" copy, and form labels. Rewrite anything that doesn't sound like Steve.

## Body plan notes for reviewer

- Page refuses to appear in main nav by design. Pros find it via direct link or footer.
- Page refuses to talk to homeowners. The "Homeowner?" redirect at the bottom is the gentle off-ramp.
- Page refuses to commit to specific referral-fee structures. Those are 1:1 conversations Steve has after a partner reaches out.
- Form refusal: not the place for homeowner intake. Subject line differentiator is the body-plan joint that keeps the two streams separate in Steve's inbox.

## Honesty notes

- All copy is best-guess Steve voice. TODO Steve marker in the source.
- The 6 pro types include an "Other pros" catch-all card I added beyond the plan's sketched 5. Light scope expansion; flagged in the agent note. Remove if you'd rather keep the list tight.
- "Real estate agents" is on the list per the plan sketch. Remove that card if Steve doesn't want that market.

## Deviations from plan

- Plan said "partner form distinct from homeowner contact form." Implementation reuses the same Web3Forms endpoint with a distinct subject rather than a separate endpoint. Simpler; same audit trail. Flagged in the agent note.
- Footer change went directly into `footer.njk` rather than populating `navigation.json`'s empty `footer` array. Simpler for a single link; if more footer links accumulate later, refactor to data-driven. Flagged in the agent note.

## Relationship to other open PRs

Independent of #8/#9/#10/#11. Any merge order works.

## What's next (slice 4)

A `/from-your-designer/` landing page for homeowners that a designer has referred to Steve for the install/build side. Different audience than `/partners/` (homeowners, not pros), parallel structure to `/after-tree-removal/`. Separate PR coming.

## Agent notes

This commit has a structured YAML note attached via `refs/notes/agent`. Run `~/.claude/bin/agent-review master..HEAD` from this branch for the structured walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
