### PR TITLE
Add /from-your-designer/ referral landing page for homeowners

### DIFF
--- a/src/from-your-designer.njk
+++ b/src/from-your-designer.njk
@@ -1,0 +1,117 @@
+---
+layout: layouts/base.njk
+title: From Your Designer, Bring the Plans to Life
+description: "Your landscape designer drew up the plans. Steve Lytle handles the install: hardscape, irrigation, planting, and lighting, faithfully built to the design and coordinated with your designer."
+---
+
+{# TODO Steve: rewrite copy in your voice where it doesn't sound like you.
+   The page structure is locked; the words are placeholder. #}
+
+{# Hero #}
+<section class="py-24 bg-gray-50">
+  <div class="container mx-auto px-4 max-w-3xl text-center">
+    <p class="text-spring font-semibold uppercase tracking-wide mb-4">Referred by your landscape designer</p>
+    <h1 class="text-5xl font-bold text-forest mb-6">Your designer drew the plans. Let's build them.</h1>
+    <p class="text-lg text-gray-700 mb-8">
+      You've worked with a landscape designer you trust. Now you need someone who builds what they drew, faithfully, on time, and with the same respect for the design you do. Steve Lytle has installed designer-led landscape projects across Orange County for over four decades.
+    </p>
+    <a href="/#contact" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg text-lg font-semibold hover:bg-spring transition-colors">
+      Schedule a Consultation
+    </a>
+  </div>
+</section>
+
+{# The handoff explained #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-3xl">
+    <h2 class="text-4xl font-bold text-forest mb-6 text-center">What happens at the handoff</h2>
+    <p class="text-lg text-gray-700 mb-4">
+      A designer's job is the vision: the layout, the plant palette, the hardscape forms, the way the garden reads from inside the house and from the street. A builder's job is bringing that vision to ground without cutting corners or improvising past the design.
+    </p>
+    <p class="text-lg text-gray-700">
+      Steve specializes in the build side. He sources the specified plants, places hardscape per the drawings, installs the irrigation that the planting plan needs, and adds the lighting the design calls for. When the site surfaces something the design didn't anticipate, Steve calls your designer rather than guessing.
+    </p>
+  </div>
+</section>
+
+{# What Steve does with your designer's plans #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 max-w-5xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-4">What Steve builds from your designer's plans</h2>
+    <p class="text-center text-gray-600 mb-12 max-w-2xl mx-auto">
+      Steve handles every layer of the install personally, with one team, on one timeline.
+    </p>
+    <div class="grid md:grid-cols-2 gap-8">
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-seedling"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Plant sourcing and installation</h3>
+        <p class="text-gray-700 mb-3">Steve sources the plants your designer specified, in the sizes and varieties on the plan. If a specified plant is genuinely unavailable, he flags it back to the designer with options, not substitutions.</p>
+        <a href="/plant-selection/" class="text-forest font-semibold hover:text-lime transition-colors">More on plants &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-mountain"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Hardscape construction</h3>
+        <p class="text-gray-700 mb-3">Patios, walkways, retaining walls, fire features, and outdoor kitchens built to the drawings. Quality materials, proper base preparation, and drainage that handles Orange County rain and dry summers.</p>
+        <a href="/hardscaping/" class="text-forest font-semibold hover:text-lime transition-colors">More on hardscaping &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-faucet"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Irrigation engineered for the planting plan</h3>
+        <p class="text-gray-700 mb-3">Zoned by hydrozone to match what your designer specified. Drip for shrub and bed areas, rotors for turf, smart controllers built in. No overspray onto hardscape.</p>
+        <a href="/irrigation-systems/" class="text-forest font-semibold hover:text-lime transition-colors">More on irrigation &rarr;</a>
+      </div>
+      <div class="bg-white p-8 rounded-lg shadow">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-lightbulb"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Landscape lighting per the design</h3>
+        <p class="text-gray-700">Path lighting, accent lighting for specimen trees, architectural uplighting, and any fixtures your designer specified. Low-voltage LED, marine-grade fixtures where the coast demands them.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# How Steve works with your designer #}
+<section class="py-16 bg-white">
+  <div class="container mx-auto px-4 max-w-5xl">
+    <h2 class="text-4xl font-bold text-center text-forest mb-12">How Steve works with your designer</h2>
+    <div class="grid md:grid-cols-2 gap-8">
+      <div class="bg-gray-50 p-8 rounded-lg">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-clipboard-check"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">The design stays the design</h3>
+        <p class="text-gray-700">Steve doesn't second-guess the layout or substitute plants without asking. The design you paid for is what gets built. If the site surfaces a real constraint, the question goes back to your designer.</p>
+      </div>
+      <div class="bg-gray-50 p-8 rounded-lg">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-comments"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Your designer stays informed</h3>
+        <p class="text-gray-700">Steve loops your designer in on major decisions, site discoveries, and any change requests. You don't have to be the messenger between two pros.</p>
+      </div>
+      <div class="bg-gray-50 p-8 rounded-lg">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-route"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">One install, one timeline, one person</h3>
+        <p class="text-gray-700">Steve walks the whole install himself. You get one point of contact for the build, not a hardscape contractor plus an irrigation crew plus a planting company plus a lighting installer.</p>
+      </div>
+      <div class="bg-gray-50 p-8 rounded-lg">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-handshake"></i></div>
+        <h3 class="text-xl font-bold text-forest mb-3">Steve respects the relationship</h3>
+        <p class="text-gray-700">Your designer is your designer. Steve doesn't pitch redesign work, doesn't poach the relationship, and doesn't bypass the design process you already paid for.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{# CTA #}
+<section class="py-16 bg-gray-50">
+  <div class="container mx-auto px-4 text-center">
+    <h2 class="text-4xl font-bold text-forest mb-6">Ready to bring the plans to life?</h2>
+    <p class="text-lg text-gray-700 mb-8">
+      Tell Steve a little about your project and your designer. He'll come walk the site and put a build plan together.
+    </p>
+    <div class="flex flex-col sm:flex-row gap-4 justify-center">
+      <a href="/#contact" class="inline-block bg-lime text-stone px-8 py-4 rounded-lg font-semibold hover:bg-spring transition-colors">
+        Schedule Consultation
+      </a>
+      <a href="tel:{{ site.phoneRaw }}" class="inline-block border-2 border-forest text-forest px-8 py-4 rounded-lg font-semibold hover:bg-forest hover:text-white transition-colors">
+        Call {{ site.phone }}
+      </a>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary

Symmetric pair to PR #11 (`/after-tree-removal/`). Steve gets referrals from landscape designers whose homeowners need someone to build what was drawn. Until now those referrals had nowhere specific to land. This adds a single-purpose landing page the designer can hand the homeowner directly.

**URL:** `/from-your-designer/` (not in nav by design)

**Slice 4 of 4** — completes the concierge epic. The four slices:

| Slice | PR | Audience | Job |
|---|---|---|---|
| 1 | #10 | Homepage visitors | Name the concierge spine |
| 2 | #11 | Homeowners referred by tree services | Convert torn-up-yard moment |
| 3 | #12 | Designers, tree services, other pros | B2B outreach asset |
| 4 | **this PR** | Homeowners referred by their designer | Convert handoff moment |

## Page structure

1. **Hero** — "Your designer drew the plans. Let's build them."
2. **What happens at the handoff** — Designer's job vs. builder's job, framed so the designer keeps their authority.
3. **What Steve builds from your designer's plans** — 4 cards: plant sourcing, hardscape construction, irrigation engineered for the planting plan, lighting per the design. Internal links to `/plant-selection/`, `/hardscaping/`, `/irrigation-systems/`.
4. **How Steve works with your designer** — 4 relationship principles: the design stays the design, your designer stays informed, one install / one timeline / one person, Steve respects the relationship.
5. **CTA** — Schedule consultation + phone.

## Voice rules specific to this page

Beyond the concierge spine, this page commits Steve to specific designer-respecting behaviors:

- Never frame Steve as a design upgrade or competitor
- Site discoveries route back to the designer, not to Steve's improvisation
- Plant substitutions are flagged to the designer with options, not made unilaterally
- No design-redesign pitch language
- The designer stays in the loop on major decisions

These are load-bearing commitments. If Steve in practice has a different working relationship with designers, the relevant cards need softening.

## Test plan

- [ ] `npm run dev`, visit `/from-your-designer/`. All 5 sections render in order.
- [ ] 4 build cards present with icons (seedling, mountain, faucet, lightbulb). Internal cross-links to the 3 service pages resolve.
- [ ] 4 relationship principle cards present. Read the copy and confirm it matches Steve's actual designer workflow. Soften any cards that overcommit.
- [ ] Mobile viewport (375px): no horizontal scroll, cards stack, form CTA usable.
- [ ] Voice pass on hero, handoff section, and relationship cards. Rewrite anything that doesn't sound like Steve.

## Body plan notes for reviewer

- Page refuses to position Steve as a design competitor. Hero defers to the designer in the first sentence.
- Page refuses to suggest design changes. The "design stays the design" card commits Steve to that.
- Page refuses to appear in main nav. Referral landing target only.
- Joints: cross-links to existing service pages drop in at exactly the moments deeper service detail would help (after the relevant build card).

## Honesty notes

- Voice is best-guess Steve. TODO Steve marker in source.
- Did NOT include soil prep or lawn restoration cards (Steve also handles these). Reasoning in the agent note: designer-led projects typically cover those layers under hardscape or planting line items, and adding more cards would make the page feel like a services list rather than a handoff narrative. Easy to add if Steve wants them.

## Implementation note

First commit attempt 404'd because the YAML frontmatter `description:` had an unquoted body containing a colon (`the install: hardscape...`). Gray-matter parser interpreted the inline colon as a new YAML key and the page failed to build. Fix: quoted the description string. Verified before the commit landed.

## Relationship to other open PRs

Independent of #8, #9, #10, #11, #12. Any merge order works. The page reads best when #10 (concierge spine) and #11 (tree-removal landing) are also live so the visitor lands on a site whose voice is consistent across referral funnels, but no functional dependency.

## Agent notes

This commit has a structured YAML note attached via `refs/notes/agent`. Run `~/.claude/bin/agent-review master..HEAD` from this branch for the structured walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
