### PR TITLE
Add Primary Service Areas section (Tustin, Orange, Villa Park) to homepage

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -190,6 +190,40 @@ description: Expert landscape design and garden consultation in Orange County by
   </div>
 </section>
 
+{# Primary Service Areas. Tustin, Orange, Villa Park where Steve focuses. #}
+{# TODO Steve: rewrite the city descriptions in your voice if they don't sound like you. #}
+<section id="primary-areas" class="py-24 bg-white">
+  <div class="container mx-auto px-4 max-w-6xl">
+    <div class="text-center mb-12">
+      <p class="text-spring font-semibold uppercase tracking-wide mb-3">Where Steve Focuses</p>
+      <h2 class="text-4xl font-bold text-forest mb-4">Tustin, Orange, and Villa Park</h2>
+      <p class="text-lg text-gray-700 max-w-2xl mx-auto">
+        Steve's primary service areas. These are the neighborhoods he knows best and where most of his projects happen. He works across Orange County, but these three are home.
+      </p>
+    </div>
+    <div class="grid md:grid-cols-3 gap-8">
+      <a href="/service-areas/tustin/" class="group bg-gray-50 p-8 rounded-lg shadow-md hover:shadow-xl transition-all duration-300 border-l-4 border-lime">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-map-marker-alt"></i></div>
+        <h3 class="text-2xl font-bold text-forest mb-3 group-hover:text-lime transition-colors">Tustin &amp; North Tustin</h3>
+        <p class="text-gray-700 mb-4">Established neighborhoods, estate gardens, and the mature trees that come with decades-old properties.</p>
+        <p class="text-forest font-semibold group-hover:text-lime transition-colors">Landscape design in Tustin &rarr;</p>
+      </a>
+      <a href="/service-areas/orange/" class="group bg-gray-50 p-8 rounded-lg shadow-md hover:shadow-xl transition-all duration-300 border-l-4 border-lime">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-map-marker-alt"></i></div>
+        <h3 class="text-2xl font-bold text-forest mb-3 group-hover:text-lime transition-colors">Orange</h3>
+        <p class="text-gray-700 mb-4">Historic homes, traditional gardens, and the character of Old Towne Orange and the surrounding neighborhoods.</p>
+        <p class="text-forest font-semibold group-hover:text-lime transition-colors">Landscape design in Orange &rarr;</p>
+      </a>
+      <a href="/service-areas/villa-park/" class="group bg-gray-50 p-8 rounded-lg shadow-md hover:shadow-xl transition-all duration-300 border-l-4 border-lime">
+        <div class="text-3xl text-lime mb-4"><i class="fas fa-map-marker-alt"></i></div>
+        <h3 class="text-2xl font-bold text-forest mb-3 group-hover:text-lime transition-colors">Villa Park</h3>
+        <p class="text-gray-700 mb-4">Larger estate landscapes and longer-arc projects across Villa Park, with the room to do ambitious design well.</p>
+        <p class="text-forest font-semibold group-hover:text-lime transition-colors">Landscape design in Villa Park &rarr;</p>
+      </a>
+    </div>
+  </div>
+</section>
+
 {# Services Section #}
 <section id="services" class="py-24 bg-gradient-to-br from-white to-gray-50">
   <div class="container mx-auto px-4 text-center">


### PR DESCRIPTION
## Summary

Steve wants his marketing focused on **Tustin, Orange, and Villa Park** — those are home and where most of his projects happen. He still serves all 11 Orange County areas on the site; the shift is emphasis, not coverage.

This PR adds a dedicated homepage section that names the three primary areas prominently without removing the broader coverage list.

## What changed

New homepage section between "Working with Steve" and "Services":

> **Where Steve Focuses**
> # Tustin, Orange, and Villa Park
>
> Steve's primary service areas. These are the neighborhoods he knows best and where most of his projects happen. He works across Orange County, but these three are home.

Three cards (Tustin / Orange / Villa Park), each:
- Lime accent border on the left to set them apart from the generic service cards elsewhere
- Map-pin icon
- City name as a clickable heading
- One-sentence characterization
- "Landscape design in [city] →" CTA linking to the existing service-area page

## What did NOT change

- `navigation.json` was already ordered with Tustin/Orange/Villa Park first in `serviceAreas`. Verified, no edit needed.
- The footer iterates `navigation.json`, so it already shows the three first.
- The existing "Some of the Areas We Serve" grid in the About section stays intact. Visitors see the full 11-city coverage there, then encounter the focus statement below it.

## Body plan notes

- Section refuses to claim Steve doesn't serve other areas. The intro explicitly says "He works across Orange County, but these three are home."
- Section refuses to know about services or Steve's bio. Those belong in adjacent sections.
- Page flow becomes: impression → person → method → **location** → offerings → proof → CTA.

## Test plan

- [ ] `npm run dev`, visit `/`. Scroll past "Working with Steve". The new "Where Steve Focuses" section should sit between it and "Our Services".
- [ ] All three cards render with lime left borders, map-pin icons, and "Landscape design in [city] →" CTAs.
- [ ] Click each card — confirms navigation to the existing service-area page.
- [ ] Read the one-sentence city descriptions. Rewrite anything that doesn't match how Steve actually characterizes each area. TODO Steve marker is in the source.
- [ ] Mobile (375px): cards stack, all three still visible, no horizontal scroll.

## Honesty notes

- City descriptions are best-guess Steve voice with TODO marker in source. Steve should overwrite with his actual sense of each area.
- "He works across Orange County, but these three are home" is the load-bearing honest framing. If that's not exactly how Steve would put it, he should rewrite the intro.

## Relationship to other open PRs

Independent of #14 (accessibility). They touch different parts of `src/index.njk` — #14 hits the hero and service grid cards, this PR adds a new section between Working with Steve and Services. Should merge cleanly in either order.

## Agent notes

This commit has a structured YAML note attached via `refs/notes/agent`. Run `~/.claude/bin/agent-review master..HEAD` from this branch for the structured walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
