### PR TITLE
Require City on the homepage contact form

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -685,6 +685,18 @@ description: Expert landscape design and garden consultation in Orange County by
           <p data-contact-form-target="error" class="mt-2 text-sm text-red-600 hidden" role="alert">Please provide either a phone number or an email address.</p>
         </div>
 
+        {# City (required) and ZIP (optional). Steve uses city to qualify leads against his focus areas. #}
+        <div class="grid grid-cols-2 gap-6">
+          <div>
+            <label for="city" class="block text-sm font-medium text-gray-700">City *</label>
+            <input type="text" id="city" name="city" required placeholder="City" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+          </div>
+          <div>
+            <label for="zip" class="block text-sm font-medium text-gray-700">ZIP Code</label>
+            <input type="text" id="zip" name="zip" placeholder="12345" pattern="\d*" maxlength="5" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
+          </div>
+        </div>
+
         {# Project Details (required) #}
         <div>
           <label for="message" class="block text-sm font-medium text-gray-700">Project Details *</label>
@@ -698,17 +710,6 @@ description: Expert landscape design and garden consultation in Orange County by
             <div>
               <label for="address" class="block text-sm font-medium text-gray-700">Project Address</label>
               <input type="text" id="address" name="address" placeholder="123 Main Street" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
-            </div>
-
-            <div class="grid grid-cols-2 gap-6">
-              <div>
-                <label for="city" class="block text-sm font-medium text-gray-700">City</label>
-                <input type="text" id="city" name="city" placeholder="City" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
-              </div>
-              <div>
-                <label for="zip" class="block text-sm font-medium text-gray-700">ZIP Code</label>
-                <input type="text" id="zip" name="zip" placeholder="12345" pattern="\d*" maxlength="5" class="mt-1 w-full rounded-lg border-gray-300 shadow-sm focus:border-forest focus:ring-forest">
-              </div>
             </div>
 
             <div>


### PR DESCRIPTION
## Summary

Steve wants the city field on the contact form to be required so he can qualify leads against his focus areas (Tustin, Orange, Villa Park) at form-submit time instead of chasing them after.

## What changed

- `city` pulled out of the optional "Add project details" collapse.
- `city` is now visible and required (label shows "City *").
- `zip` came up with it visually (paired in a 2-col grid, matching the original pre-trim layout) but stays optional.
- `address`, `service`, `referral_source` remain optional inside the collapse.

## New required surface

```
name (required)
phone OR email (at least one — enforced by Stimulus validator)
city (required)
message (required)
hCaptcha
```

ZIP, address, service type, and referral source are still optional inside the "Add project details" collapse.

## Trade-off worth knowing

The original form trim (#8) cut required fields from 9 to 2 to address the 87 form_starts → 14 form_submits problem from the GA4 audit (16% conversion). Adding city back to required adds one field of friction. Steve's judgment is that losing out-of-area leads at form time is cheaper than chasing them after submit. Worth watching the conversion rate over the next 30 days; if it drops materially below 16%, revisit.

## Test plan

- [ ] `npm run dev`, visit `/#contact`. City field is visible (not inside the collapse), paired with ZIP.
- [ ] Try submitting with name, phone OR email, message, but no city. Browser blocks submit with "Please fill out this field" on the city input.
- [ ] Try submitting with name, city, phone, message. Should succeed.
- [ ] Mobile (375px): city/zip row stacks or stays 2-col depending on the grid behavior; no horizontal scroll.

## Agent notes

This commit has a structured YAML note attached via `refs/notes/agent`. Run `~/.claude/bin/agent-review master..HEAD` from this branch for the structured walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
